### PR TITLE
Add data interpolation to rich text editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7245,6 +7245,12 @@
       "integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
       "dev": true
     },
+    "mustache": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-3.0.1.tgz",
+      "integrity": "sha512-jFI/4UVRsRYdUbuDTKT7KzfOp7FiD5WzYmmwNwXyUVypC0xjoTL78Fqc0jHUPIvvGD+6DQSPHIt1NE7D1ArsqA==",
+      "dev": true
+    },
     "mute-stream": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",

--- a/package.json
+++ b/package.json
@@ -43,10 +43,14 @@
     "@vue/cli-plugin-babel": "^3.0.0-beta.15",
     "@vue/cli-plugin-eslint": "^3.0.0-beta.15",
     "@vue/cli-service": "^3.0.0-beta.15",
+    "mustache": "^3.0.1",
     "node-sass": "^4.9.0",
     "sass-loader": "^7.0.3",
     "vue-template-compiler": "^2.5.16",
     "vue-uniq-ids": "^1.0.0"
+  },
+  "peerDependencies": {
+    "mustache": "^3.0.1"
   },
   "eslintConfig": {
     "root": true,

--- a/src/components/FormHtmlEditor.vue
+++ b/src/components/FormHtmlEditor.vue
@@ -4,7 +4,7 @@
       <editor
         v-on="$listeners"
         v-bind="$attrs"
-        :value="content"
+        :value="rendered"
         :init="editorSettings"
       />
     </div>
@@ -21,6 +21,7 @@
 import { createUniqIdsMixin } from 'vue-uniq-ids'
 import ValidationMixin from './mixins/validation'
 import Editor from '@tinymce/tinymce-vue';
+import Mustache from 'mustache';
 import 'tinymce/tinymce';
 import 'tinymce/themes/silver';
 import 'tinymce/plugins/link';
@@ -43,6 +44,7 @@ export default {
     'helper',
     'controlClass',
     'content',
+    'validationData',
   ],
   computed:{
     classList(){
@@ -53,6 +55,17 @@ export default {
         classList[this.controlClass] = true
       }
       return classList
+    },
+    rendered() {
+      if (!this.validationData) {
+        return this.content;
+      }
+
+      try {
+        return Mustache.render(this.content, this.validationData);
+      } catch (error) {
+        return this.content;
+      }
     }
   },
   data() {


### PR DESCRIPTION
This PR adds data interpolation to the rich text editor, similar to `Text` component in the screen builder. Related PR: https://github.com/ProcessMaker/spark-screen-builder/pull/152.