### PR TITLE
Prevent empty string being set by default

### DIFF
--- a/src/components/mixins/DataFormat.js
+++ b/src/components/mixins/DataFormat.js
@@ -35,7 +35,7 @@ export default {
     },
     formatValue(value) {
       if (!value && this.dataFormat !== 'boolean') {
-        return '';
+        return value;
       }
       this.dataTypeValidatorPasses = this.validateRuleFormat(value);
       return this.dataTypeValidatorPasses ? this.formatValueIfValid(value) : value;


### PR DESCRIPTION
This PR prevent empty string being set by default in form controls.

Returning an empty string was causing a property to be set in the XML output in modeler unexpectedly.

This PR is required to fix https://github.com/ProcessMaker/modeler/issues/500.