### PR TITLE
Fix the formatting of a decimal

### DIFF
--- a/src/components/FormInput.vue
+++ b/src/components/FormInput.vue
@@ -9,6 +9,7 @@
       :name="name"
       class="form-control"
       :class="classList"
+      v-on:blur="formatFloatValue()"
     >
       <template v-if="validator && validator.errorCount">
         <div class="invalid-feedback" v-for="(errors, index) in validator.errors.all()" :key="index">

--- a/src/components/mixins/DataFormat.js
+++ b/src/components/mixins/DataFormat.js
@@ -22,6 +22,7 @@ export default {
     return {
       dataTypeValidator: null,
       dataTypeValidatorPasses: true,
+      formatted: ''
     };
   },
   watch: {
@@ -57,6 +58,12 @@ export default {
       this.dataTypeValidator = new Validator( {[this.name]: value}, {[this.name]: rules[this.dataFormat]}, null);
       return this.dataTypeValidator.passes();
     },
+    formatFloatValue() {
+      if ( this.dataFormat == 'float' && this.dataTypeValidator.passes() ) {
+        this.value = Number(this.value);
+        return this.$emit('input', this.value);
+      }
+    },
     formatValueIfValid(newValue) {
       switch (this.dataFormat) {
         case 'string':
@@ -74,9 +81,6 @@ export default {
         case 'datetime':
           newValue = newValue.toString();
           break;
-        case 'float':
-          newValue = Number(newValue);
-          break;
         case 'int':
           newValue = parseInt(newValue);
           break;
@@ -86,5 +90,6 @@ export default {
       }
       return newValue;
     },
+    
   },
 };


### PR DESCRIPTION
The issue is caused by the `watch` property that calls the `Numbers` method for the decimal value. As a user typing zeros, the input would auto-format the value while typing and strip the zeros. 0.1 would format to .1 and be considered an invalid format, 100.01 would format to 1001. 

In this fix, the `Numbers`method was removed from the `watch` property and stored in a new method `formatFloatValue`. `formatFloatValue` is triggered on input blur, allowing for the leading zeros to be removed after the user is done typing. 

closes [#318](https://github.com/ProcessMaker/screen-builder/issues/318#issue-476938117)