### PR TITLE
Update the selected default radio option value

### DIFF
--- a/src/components/FormRadioButtonGroup.vue
+++ b/src/components/FormRadioButtonGroup.vue
@@ -46,6 +46,7 @@ export default {
   computed: {
     selectedValue() {
       if (!this.value && this.radioOptions.length > 0) {
+        this.$emit('input', this.radioOptions[0].value);
         return this.radioOptions[0].value;
       }
 


### PR DESCRIPTION
The value was not being updated for the default option. The value would only be updated on the `change` method, resulting in having to select another option first before submitting the form. 

video of fix: https://www.dropbox.com/s/5ymm7tzox61k2a1/media.io_screen-capture%20%282%29.mp4?dl=0

closes #321[https://github.com/ProcessMaker/screen-builder/issues/321](url)