### PR TITLE
Change Date Picker

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2683,7 +2683,8 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "coa": {
       "version": "2.0.2",
@@ -4804,7 +4805,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4825,12 +4827,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4845,17 +4849,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4972,7 +4979,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4984,6 +4992,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4998,6 +5007,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5005,12 +5015,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5029,6 +5041,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5109,7 +5122,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5121,6 +5135,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5206,7 +5221,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5242,6 +5258,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5261,6 +5278,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5304,12 +5322,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6696,6 +6716,7 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
+      "optional": true,
       "requires": {
         "prelude-ls": "~1.1.2",
         "type-check": "~0.3.2"
@@ -6916,11 +6937,6 @@
       "requires": {
         "yallist": "^3.0.2"
       }
-    },
-    "luxon": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.13.2.tgz",
-      "integrity": "sha512-U7i2AE+/VWeB8PZZkIeEcxJCZvBA8LegCHufaIFYx3qRQdw2UJw3fuaL/Fqi9Q+2MeFYu+gYqIzr5hWOvAMHBQ=="
     },
     "make-dir": {
       "version": "2.1.0",
@@ -8757,7 +8773,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "prepend-http": {
       "version": "2.0.0",
@@ -9479,7 +9496,8 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
@@ -10926,6 +10944,7 @@
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
+      "optional": true,
       "requires": {
         "prelude-ls": "~1.1.2"
       }
@@ -11314,11 +11333,6 @@
       "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
       "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ=="
-    },
-    "vue-datetime": {
-      "version": "1.0.0-beta.10",
-      "resolved": "https://registry.npmjs.org/vue-datetime/-/vue-datetime-1.0.0-beta.10.tgz",
-      "integrity": "sha512-/wJkj95JSzWqH0Ja4JpXX6I+fXo2A34GCtsx00vR5RjNxk3++93rg7G4ZlI3MFo807zH9bIxXfIohbAZgnAWbQ=="
     },
     "vue-eslint-parser": {
       "version": "2.0.3",
@@ -11810,11 +11824,6 @@
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
       "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
       "dev": true
-    },
-    "weekstart": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/weekstart/-/weekstart-1.0.0.tgz",
-      "integrity": "sha1-4K7jWNRa2ZgCJUdp17KjTJOA9Tk="
     },
     "which": {
       "version": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6938,6 +6938,11 @@
         "yallist": "^3.0.2"
       }
     },
+    "luxon": {
+      "version": "1.17.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.17.2.tgz",
+      "integrity": "sha512-qELKtIj3HD41N+MvgoxArk8DZGUb4Gpiijs91oi+ZmKJzRlxY6CoyTwNoUwnogCVs4p8HuxVJDik9JbnYgrCng=="
+    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -7276,6 +7281,19 @@
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
+      }
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
+    "moment-timezone": {
+      "version": "0.5.26",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.26.tgz",
+      "integrity": "sha512-sFP4cgEKTCymBBKgoxZjYzlSovC20Y6J7y3nanDc5RoBIXKlZhoYwBoZGe3flwU6A372AcRwScH8KiwV6zjy1g==",
+      "requires": {
+        "moment": ">= 2.9.0"
       }
     },
     "move-concurrently": {
@@ -8094,6 +8112,27 @@
         "ripemd160": "^2.0.1",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "pc-bootstrap4-datetimepicker": {
+      "version": "4.17.50",
+      "resolved": "https://registry.npmjs.org/pc-bootstrap4-datetimepicker/-/pc-bootstrap4-datetimepicker-4.17.50.tgz",
+      "integrity": "sha512-76y2McdmiGWdgwPUim72/otNcDUva05B/VoyJVgIRv2dd+g4GO9gPfvvPvCH4LXyKNvtAzKHQSTSyC+4PKq/FQ==",
+      "requires": {
+        "bootstrap": "^4.0.0-beta.2",
+        "jquery": "^1.8.3 || ^2.0 || ^3.0",
+        "moment": "^2.10",
+        "moment-timezone": "^0.4.0"
+      },
+      "dependencies": {
+        "moment-timezone": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz",
+          "integrity": "sha1-gfWYw61eIs2teWtn7NjYjQ9bqgY=",
+          "requires": {
+            "moment": ">= 2.6.0"
+          }
+        }
       }
     },
     "performance-now": {
@@ -11333,6 +11372,14 @@
       "version": "2.6.10",
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.10.tgz",
       "integrity": "sha512-ImThpeNU9HbdZL3utgMCq0oiMzAkt1mcgy3/E6zWC/G6AaQoeuFdsl9nDhTDU3X1R6FK7nsIUuRACVcjI+A2GQ=="
+    },
+    "vue-bootstrap-datetimepicker": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/vue-bootstrap-datetimepicker/-/vue-bootstrap-datetimepicker-5.0.1.tgz",
+      "integrity": "sha512-jao7sWXHgKzjbOio97u7kEfB/FJMWJ5rhsc4q8iNTOLCULfSJ5m3AZ2qZh62dNcMA4/uuTW6m6tONYIith/2XQ==",
+      "requires": {
+        "pc-bootstrap4-datetimepicker": "^4.17.50"
+      }
     },
     "vue-eslint-parser": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -30,14 +30,11 @@
     "@tinymce/tinymce-vue": "^2.0.0",
     "bootstrap": "^4.2.1",
     "jquery": "^3.3.1",
-    "luxon": "^1.11.3",
     "popper.js": "^1.14.4",
     "tinymce": "^5.0.1",
     "v-calendar": "^0.9.7",
     "validatorjs": "^3.14.2",
-    "vue": "^2.5.16",
-    "vue-datetime": "^1.0.0-beta.10",
-    "weekstart": "^1.0.0"
+    "vue": "^2.5.16"
   },
   "devDependencies": {
     "@panter/vue-i18next": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -30,11 +30,14 @@
     "@tinymce/tinymce-vue": "^2.0.0",
     "bootstrap": "^4.2.1",
     "jquery": "^3.3.1",
+    "luxon": "^1.17.2",
+    "moment-timezone": "^0.5.26",
     "popper.js": "^1.14.4",
     "tinymce": "^5.0.1",
     "v-calendar": "^0.9.7",
     "validatorjs": "^3.14.2",
-    "vue": "^2.5.16"
+    "vue": "^2.5.16",
+    "vue-bootstrap-datetimepicker": "^5.0.1"
   },
   "devDependencies": {
     "@panter/vue-i18next": "^0.15.0",

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -5,10 +5,9 @@
             v-model="date" 
             v-on="$listeners" 
             v-bind="$attrs"
-            :config="configs" 
+            :config="config" 
             :class="{inputClass, 'is-invalid' : validator}"
             :placeholder="placeholder"
-            :change="this.update()"
     ></date-picker>
     <div v-if="(validator && validator.errorCount) || error" class="invalid-feedback d-block">
         <div v-for="(error, index) in validator.errors.get(this.name)" :key="index">{{error}}</div>
@@ -24,7 +23,6 @@
   import {createUniqIdsMixin} from 'vue-uniq-ids';
   import ValidationMixin from './mixins/validation';
   import DataFormatMixin from "./mixins/DataFormat";
-  import 'bootstrap/dist/css/bootstrap.css';
   import datePicker from 'vue-bootstrap-datetimepicker';
   import 'pc-bootstrap4-datetimepicker/build/css/bootstrap-datetimepicker.css';
   import moment from 'moment-timezone'
@@ -49,7 +47,7 @@
     data() {
       return {
         date: null,
-        configs: {
+        config: {
           format: '',
           timeZone: '',
           locale: '',
@@ -70,35 +68,29 @@
         },
       }
     },
-    methods: {
-      update() {
-        if (this.dataFormat === 'datetime') {
-          this.configs.format = 'MM/DD/YYYY h:mm:ss A';
-        } else {
-          this.configs.format = 'MM/DD/YYYY';
-        }
-
-        if (typeof ProcessMaker !== 'undefined' && ProcessMaker.user) {
-          if (ProcessMaker.user.timezone) {
-            this.configs.timeZone = ProcessMaker.user.timezone;
-          }  else  {
-            this.configs.timeZone = 'local';
-          }
-          
-          if (ProcessMaker.user.app_timezone) {
-            this.configs.timeZone = ProcessMaker.user.app_timezone;
-          } else  {
-            this.configs.timeZone = 'UTC';  
-          }
-        }
-
-        if (typeof ProcessMaker !== 'undefined' && ProcessMaker.user && ProcessMaker.user.lang) {
-          this.configs.locale = ProcessMaker.user.lang;
-        } else  {
-          this.configs.locale = 'en';
-        }
-
+    watch: {
+      dataFormat() {
+        this.updateFormat();
       }
     },
+    methods: {
+      updateFormat() {
+        if (this.dataFormat == 'datetime') {
+          this.config.format = 'MM/DD/YYYY h:mm A';
+        } else {
+          this.config.format = 'MM/DD/YYYY';
+        }
+      },
+      setTimezone() {
+        this.config.timeZone = ProcessMaker.user.timezone || 'local';
+      },
+      setLang() {
+        this.config.locale = ProcessMaker.user.lang || 'en';
+      }
+     },
+     mounted() {
+       this.setTimezone();
+       this.setLang();
+     }
   };
 </script>


### PR DESCRIPTION
Removes 'vue-datepicker' and replaces with 'vue-bootstrap-datetimepicker'.

Fixes:
1. The ability to type the date into the input box or select from the calendar popout.
2. The ability to select time only when the 'datetime' data type is selected.

closes [#2296](https://github.com/ProcessMaker/processmaker/issues/2296) [#313](https://github.com/ProcessMaker/screen-builder/issues/313) [#317](https://github.com/ProcessMaker/screen-builder/issues/317) 