### PR TITLE
Fix issues caused by removal of type checks

### DIFF
--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -1,11 +1,11 @@
 <template>
   <div class="form-group">
     <label v-uni-for="name">{{label}}</label>
-    <date-picker ref="datePicker" 
-            v-model="date" 
-            v-on="$listeners" 
+    <date-picker ref="datePicker"
+            v-model="date"
+            v-on="$listeners"
             v-bind="$attrs"
-            :config="config" 
+            :config="config"
             :class="{inputClass, 'is-invalid' : validator}"
             :placeholder="placeholder"
     ></date-picker>
@@ -25,7 +25,6 @@
   import DataFormatMixin from "./mixins/DataFormat";
   import datePicker from 'vue-bootstrap-datetimepicker';
   import 'pc-bootstrap4-datetimepicker/build/css/bootstrap-datetimepicker.css';
-  import moment from 'moment-timezone'
 
   const uniqIdsMixin = createUniqIdsMixin();
 
@@ -82,10 +81,14 @@
         }
       },
       setTimezone() {
-        this.config.timeZone = ProcessMaker.user.timezone || 'local';
+        if (typeof ProcessMaker !== 'undefined' && ProcessMaker.user) {
+          this.config.timeZone = ProcessMaker.user.timezone || 'local';
+        }
       },
       setLang() {
-        this.config.locale = ProcessMaker.user.lang || 'en';
+        if (typeof ProcessMaker !== 'undefined' && ProcessMaker.user) {
+          this.config.locale = ProcessMaker.user.lang || 'en';
+        }
       }
      },
      mounted() {


### PR DESCRIPTION
This PR reintroduces null checking around the `ProcessMaker` and `ProcessMaker.user` variables. This is required as this package is used in other projects that may not have defined these variables (such as the modeler project when run as a standalone app).

It seems to me here that there's a larger issue that needs to be addressed here: this package should not be aware of or attempt to use variables that are defined in other packages. I'd love to see how we can refactor this code to remove the dependency on the ProcessMaker object.