### PR TITLE
Fix broken build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11428,12 +11428,6 @@
         "vue-style-loader": "^4.1.0"
       }
     },
-    "vue-multiselect": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/vue-multiselect/-/vue-multiselect-2.1.6.tgz",
-      "integrity": "sha512-s7jmZPlm9FeueJg1RwJtnE9KNPtME/7C8uRWSfp9/yEN4M8XcS/d+bddoyVwVnvFyRh9msFo0HWeW0vTL8Qv+w==",
-      "dev": true
-    },
     "vue-style-loader": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11428,6 +11428,12 @@
         "vue-style-loader": "^4.1.0"
       }
     },
+    "vue-multiselect": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/vue-multiselect/-/vue-multiselect-2.1.6.tgz",
+      "integrity": "sha512-s7jmZPlm9FeueJg1RwJtnE9KNPtME/7C8uRWSfp9/yEN4M8XcS/d+bddoyVwVnvFyRh9msFo0HWeW0vTL8Qv+w==",
+      "dev": true
+    },
     "vue-style-loader": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "mustache": "^3.0.1",
     "node-sass": "^4.9.0",
     "sass-loader": "^7.0.3",
+    "vue-template-compiler": "^2.5.16",
     "vue-uniq-ids": "^1.0.0",
     "vue-multiselect": "^2.1.3"
   },

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -21,6 +21,7 @@
   import {createUniqIdsMixin} from 'vue-uniq-ids';
   import ValidationMixin from './mixins/validation';
   import DataFormatMixin from "./mixins/DataFormat";
+  import datePicker from 'vue-bootstrap-datetimepicker';
   import 'pc-bootstrap4-datetimepicker/build/css/bootstrap-datetimepicker.css';
   import moment from 'moment-timezone';
 
@@ -30,11 +31,7 @@
     inheritAttrs: false,
     mixins: [uniqIdsMixin, ValidationMixin, DataFormatMixin],
     components: {
-      datePicker: () => {
-        if (typeof window !== 'undefined') {
-          return import(/* webpackChunkName: "datePicker" */ 'vue-bootstrap-datetimepicker');
-        }
-      }
+      datePicker
     },
     props: {
       name: String,

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -99,7 +99,7 @@
         }
       },
       setDate() {
-        this.date = moment.utc(this.value).format();
+        this.date = moment(this.value);
       }
      },
      mounted() {


### PR DESCRIPTION
This PR reverts the changes in https://github.com/ProcessMaker/vue-form-elements/pull/91 and https://github.com/ProcessMaker/vue-form-elements/pull/89.

The changes in https://github.com/ProcessMaker/vue-form-elements/pull/91 removed `vue-template-compiler`, however, `vue-template-compiler` is required to build the app:

> This package can be used to pre-compile Vue 2.0 templates into render functions to avoid runtime-compilation overhead and CSP restrictions. In most cases you should be using it with vue-loader.

Without `vue-template-compiler`, running `npm run build-bundle` produces the following error:
```
Building for production as library (commonjs,umd,umd-min)... ERROR  Error: Cannot find module ‘vue-template-compiler/package.json’
```

The changes in https://github.com/ProcessMaker/vue-form-elements/pull/89 caused a bug in modeler that prevented the date from saving for the _Start Timer Event_. Formatting the date was not actually required and was not the cause of the failing tests.