### PR TITLE
Fix date formatting

### DIFF
--- a/src/DemoApp.vue
+++ b/src/DemoApp.vue
@@ -88,12 +88,9 @@
                 label="Sample calendar"
                 placeholder="Placeholder Sample Calendar"
                 helper="Helper Sample Calendar, Theming is supported by overwriting CSS classes."
-                format="yyyy-MM-dd tttt"
-                :use12-hour="true"
-                :minuteStep="2"
-                :phrases="{ ok: 'Save', cancel: 'Cancel' }"
-                v-model="data.sampleDatePicker">
-        </form-date-picker>
+                data-format="datetime"
+                v-model="data.sampleDatePicker"
+        />
         <form-html-editor
             name="sampleHtmlText"
             label="Sample Html Editor"

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -1,12 +1,13 @@
 <template>
   <div class="form-group position-relative">
     <label v-uni-for="name">{{label}}</label>
-    <date-picker :config="config"
-                 v-model="date"
-                 :disabled="$attrs.disabled"
-                 :placeholder="placeholder"
-                 :data-test="$attrs['data-test']"
-    ></date-picker>
+    <date-picker
+      :config="config"
+      v-model="date"
+      :disabled="disabled"
+      :placeholder="placeholder"
+      :data-test="dataTest"
+    />
     <div v-if="(validator && validator.errorCount) || error" class="invalid-feedback d-block">
         <div v-for="(error, index) in validator.errors.get(this.name)" :key="index">{{error}}</div>
         <div v-if="error">{{error}}</div>
@@ -28,7 +29,6 @@
   const uniqIdsMixin = createUniqIdsMixin();
 
   export default {
-    inheritAttrs: false,
     mixins: [uniqIdsMixin, ValidationMixin, DataFormatMixin],
     components: {
       datePicker
@@ -42,6 +42,8 @@
       dataFormat: String,
       value: String,
       inputClass: {type: [String, Array, Object], default: 'form-control'},
+      dataTest: String,
+      disabled: null,
     },
     data() {
       return {
@@ -68,24 +70,23 @@
       }
     },
     watch: {
-      dataFormat() {
-        this.updateFormat();
+      dataFormat: {
+        handler() { this.updateFormat() },
+        immediate: true,
       },
       value() {
         this.setDate();
       },
       date() {
-        if (typeof this.date === "string") {
-          this.$emit('input', this.date);
-        }
+        this.$emit('input', moment(this.date).toISOString());
       }
     },
     methods: {
       updateFormat() {
+        this.config.format = 'MM/DD/YYYY';
+
         if (this.dataFormat === 'datetime') {
-          this.config.format = 'MM/DD/YYYY h:mm A';
-        } else  {
-          this.config.format = 'MM/DD/YYYY';
+          this.config.format += ' h:mm A';
         }
       },
       setTimezone() {

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -90,12 +90,12 @@
       },
       setTimezone() {
         if (typeof ProcessMaker !== 'undefined' && ProcessMaker.user) {
-          this.config.timeZone = ProcessMaker.user.timezone || 'local';  
-        } 
+          this.config.timeZone = ProcessMaker.user.timezone || 'local';
+        }
       },
       setLang() {
         if (typeof ProcessMaker !== 'undefined' && ProcessMaker.user) {
-          this.config.locale = ProcessMaker.user.lang || 'en';  
+          this.config.locale = ProcessMaker.user.lang || 'en';
         }
       },
       setDate() {

--- a/src/components/FormMultiSelect.vue
+++ b/src/components/FormMultiSelect.vue
@@ -25,11 +25,6 @@
 
   const uniqIdsMixin = createUniqIdsMixin();
 
-  function removeInvalidOptions(option) {
-    return Object.keys(option).includes('value', 'content') &&
-      option.content != null;
-  }
-
   export default {
     inheritAttrs: false,
     components: {

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -156,7 +156,7 @@ export default {
 
   },
   methods: {
-    sendSelectedOptions(event) {
+    sendSelectedOptions() {
       let valueToSend = (this.selectedOptions.constructor === Array)
                         ? this.selectedOptions
                         : [this.selectedOptions];
@@ -199,7 +199,7 @@ export default {
       return this.optionsFromDataSource;
     },
     optionsFromDataSource() {
-      const { jsonData, key, value, dataName, renderAs, allowMultiSelect } = this.options;
+      const { jsonData, key, value, dataName, allowMultiSelect } = this.options;
 
       this.allowMultiSelect = allowMultiSelect;
       let options = [];


### PR DESCRIPTION
Related issue: https://github.com/ProcessMaker/modeler/issues/656.

It seems the datepicker was not picking up the initially specified date format (`datetime` vs `date`). The date picker was also emitting the date in a new format that the modeler was not expecting. This PR fixes those issues.

These changes were tested on the `develop` branch of screen-builder and on the `656-fix-datepicker-formatting` branch (https://github.com/ProcessMaker/modeler/pull/658) of modeler.