### PR TITLE
Removed 12 hour and am/pm format from date format

### DIFF
--- a/src/dateUtils.js
+++ b/src/dateUtils.js
@@ -17,7 +17,7 @@ export function getLang() {
 
 export function getUserDateFormat() {
   if (typeof ProcessMaker !== 'undefined' && ProcessMaker.user) {
-    return ProcessMaker.user.datetime_format.replace(/ |H|:|m|s|z|Z/g, '');
+    return ProcessMaker.user.datetime_format.replace(/ |H|h|:|m|s|a|A|z|Z/g, '');
   }
 
   return 'MM/DD/YYYY';

--- a/src/dateUtils.js
+++ b/src/dateUtils.js
@@ -17,7 +17,7 @@ export function getLang() {
 
 export function getUserDateFormat() {
   if (typeof ProcessMaker !== 'undefined' && ProcessMaker.user) {
-    return ProcessMaker.user.datetime_format.replace(/ |H|h|:|m|s|a|A|z|Z/g, '');
+    return ProcessMaker.user.datetime_format.replace(/[\sHh:msaAzZ]/g, '');
   }
 
   return 'MM/DD/YYYY';


### PR DESCRIPTION
Closes https://github.com/ProcessMaker/modeler/issues/733

The `End On` date for Start Timer Event, when date format is "**m/d/Y h:i A**" should no longer contain 12 hour and am/pm time. It should also save the end date when you click off/on the Start Event element (remember to select a weekday).

IE: **10/30/201910PM** should be **10/30/2019**

Debating removing everything after the space.