### PR TITLE
fix error when mapping options from an DataObject in the DataSource

### DIFF
--- a/src/components/FormRadioButtonGroup.vue
+++ b/src/components/FormRadioButtonGroup.vue
@@ -73,7 +73,7 @@ export default {
 
       if (dataName) {
         try {
-          options = this.validationData[dataName]
+          options = Object.values(this.validationData[dataName])
             .map(convertToSelectOptions)
             .filter(removeInvalidOptions);
         } catch (error) {

--- a/src/components/FormSelect.vue
+++ b/src/components/FormSelect.vue
@@ -90,7 +90,7 @@ export default {
 
       if (dataName) {
         try {
-          options = this.validationData[dataName]
+          options = Object.values(this.validationData[dataName])
             .map(convertToSelectOptions)
             .filter(removeInvalidOptions);
         } catch (error) {

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -220,7 +220,7 @@ export default {
 
       if (dataName) {
         try {
-          options = this.validationData[dataName]
+          options = Object.values(this.validationData[dataName])
             .map(convertToSelectOptions)
             .filter(removeInvalidOptions);
         } catch (error) {


### PR DESCRIPTION
**Bug**
Options for `FormSelect`, `FormSelectList` & `FormRadioButtonGroup`were not populating when selecting `DataObject` as a `Data Source`. 

**Fix:** 
Return an array of the given object by using `Object.values` before calling the `.map(convertToSelectOptions)` method.

closes [#398](https://github.com/ProcessMaker/screen-builder/issues/398) in Screen Builder