### PR TITLE
When component value is cleared. Clear the validator message.

### DIFF
--- a/src/components/mixins/validation.js
+++ b/src/components/mixins/validation.js
@@ -45,6 +45,10 @@ export default {
     },
     methods: {
         updateValidation() {
+            if (!this.value) {
+                this.validator = null;
+                return;
+            }
             if (this.validation) {
                 let fieldName = this.validationField ? this.validationField : this.name;
                 let data = this.validationData ? this.validationData : {[fieldName]: this.value}


### PR DESCRIPTION
Closes https://github.com/ProcessMaker/screen-builder/issues/435

Needs another solution if the text remains after switching between design and preview modes. Currently, value is cleared and that is expected.