### PR TITLE
Allow HTML to be passed in helper text

### DIFF
--- a/src/components/FormInput.vue
+++ b/src/components/FormInput.vue
@@ -19,7 +19,7 @@
         </div>
       </template>
       <div class="invalid-feedback" v-if="error">{{error}}</div>
-    <small v-if="helper" class="form-text text-muted">{{helper}}</small>
+    <small v-if="helper" class="form-text text-muted" v-html="helper"/>
   </div>
 </template>
 


### PR DESCRIPTION
This change allows things like links to optionally be passed into helper text. It does potentially make things slightly less secure but I think the only attack vector would be if unfiltered input was used in helper text. The chances of this seem minimal so I think this change is ok.