### PR TITLE
Select List with attributes deep in the object hierarchy are not working

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -239,7 +239,7 @@
           valueToSend = new Array(valueToSend[valueToSend.length - 1]);
         }
 
-        this.$emit('input', val);
+        this.$emit('input', valueToSend);
       },
 
       optionsFromDataSource() {

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -146,14 +146,16 @@
               }
             })
             .then(response => {
-              let list = (dataName) ? response.data[dataName] : response.data;
+              var list = dataName ? eval('response.data.' + dataName) : response.data;
               list.forEach(item => {
                 // if the content has a mustache expression
                 let itemContent = (value.indexOf('{{') >= 0)
                   ? Mustache.render(value, item)
                   : item[value || 'content'].toString();
 
-                let itemValue = (item[key || 'value']).toString();
+                let itemValue = (key.indexOf('{{') >= 0)
+                  ? Mustache.render(key, item)
+                  : item[key || 'value'].toString();
 
                 options.push({
                   value: itemValue,
@@ -227,7 +229,6 @@
     },
     methods: {
       sendSelectedOptions() {
-        console.log(this.selectedOptions);
         let valueToSend = (this.selectedOptions.constructor === Array)
           ? this.selectedOptions
           : [this.selectedOptions];


### PR DESCRIPTION
Resolves #136 

- To use a content/value deep attribute, Mustache syntax must be used.
- As a model, when using endopoints of the Collections package this format should be used:

Element Name = response.data
content= {{data.RecordField1}}
content= {{data.RecordField2}}

where RecordField1 and 2 are fields of the data inside records of  collections
