### PR TITLE
Date Picker Locks Up Screen

### DIFF
--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -75,49 +75,34 @@ export default {
       date: {
           deep:true,
         handler(value) {
-            console.info('Watch date');
             let current = value;
             if (typeof value === 'object') {
-                console.info('emit input by object');
-                console.log(typeof value);
             } else if (typeof value === 'string') {
-                console.info('emit input by string');
                 current = moment(value);
-                console.log(typeof current);
             }
-            console.log(current);
-            console.log(typeof current);
             this.$emit('input', this.emitIso ? current.toISOString() : current.format(this.config.format));
         }
       },
     dataFormat: {
       immediate: true,
       handler() {
-          console.info('watch date format');
         this.config.format = this.dataFormat === 'datetime'
           ? getUserDateTimeFormat()
           : getUserDateFormat();
-        console.log(this.config.format);
-        //moment.tz.setDefault(this.config.timeZone);
 
         this.date = moment(this.value).tz(this.config.timeZone);
-        console.log(this.date);
       }
     },
     value: {
-          deep:true,
+        deep:true,
         handler(value)
         {
-            console.info('watch value');
-            console.log(value);
             //this.date = moment(value).tz(this.config.timeZone);
         }
     },
   },
   methods: {
     setDate(date) {
-        console.info('set date');
-        console.log(date);
       const currentDate = moment(this.date).tz(this.config.timeZone);
       const newDate = moment.tz(moment(date).format('YYYY-MM-DDTHH:mm:ss'), 'YYYY-MM-DDTHH:mm:ss', this.config.timeZone);
 


### PR DESCRIPTION
Resolves #138 

This ticket resolves the Screen Builder issue 
https://github.com/ProcessMaker/screen-builder/issues/458

The emit function was moved from the setData to the corresponding watcher to avoid an infinite loop that happened when the timezone of the user and the timezone of the browser were different.