### PR TITLE
Update Validation

### DIFF
--- a/src/components/mixins/validation.js
+++ b/src/components/mixins/validation.js
@@ -45,10 +45,6 @@ export default {
     },
     methods: {
         updateValidation() {
-            if (!this.value) {
-                this.validator = null;
-                return;
-            }
             if (this.validation) {
                 let fieldName = this.validationField ? this.validationField : this.name;
                 let data = this.validationData ? this.validationData : {[fieldName]: this.value}
@@ -64,6 +60,10 @@ export default {
 
             // Show data type validation messages if exists
             if (this.dataTypeValidator && !this.dataTypeValidatorPasses) {
+                if (!this.value) {
+                    this.validator = null;
+                    return;
+                }
                 this.validator = this.dataTypeValidator;
             }
         }


### PR DESCRIPTION
<h2>Issue</h2>
Validation returning `null` on an empty input that is required.

<h2>Fix</h2>
Move the 'value' conditional under the `dataTypeValidator` conditinal in the `updateValidation` method.

Closes #140 

**BEFORE**
![Screen Shot 2019-12-12 at 12 41 32 PM](https://user-images.githubusercontent.com/52755494/70827722-a8aa6900-1d9e-11ea-940a-ee01748c9b3c.png)

**AFTER**
![Screen Shot 2019-12-13 at 11 18 50 AM](https://user-images.githubusercontent.com/52755494/70825894-64b56500-1d9a-11ea-84bf-0c380fcd069e.png)

 Fix for the original issue of [Data Type errors not clearing](https://github.com/ProcessMaker/screen-builder/issues/435) still works.  See the video below.

**note:**
There is still an issue where the input field is not clearing when toggling between Design & Preview. Will create another ticket for that issue specifically. 

https://www.loom.com/share/ea68b38b4dcf4dd59da02cef83e4932e