### PR TITLE
Clean up date picker component

### DIFF
--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -2,12 +2,12 @@
     <div class="form-group position-relative">
         <label v-uni-for="name">{{label}}</label>
         <date-picker
-          v-model="date"
-          :config="config"
-          :value="date"
-          :disabled="disabled"
-          :placeholder="placeholder"
-          :data-test="dataTest"
+              v-model="date"
+              :config="config"
+              :value="date"
+              :disabled="disabled"
+              :placeholder="placeholder"
+              :data-test="dataTest"
         />
         <div v-if="(validator && validator.errorCount) || error" class="invalid-feedback d-block">
             <div v-for="(error, index) in validator.errors.get(this.name)" :key="index">{{error}}</div>
@@ -72,17 +72,19 @@ export default {
     }
   },
   watch: {
-      date: {
-          deep:true,
-        handler(value) {
-            let current = value;
-            if (typeof value === 'object') {
-            } else if (typeof value === 'string') {
-                current = moment(value);
-            }
-            this.$emit('input', this.emitIso ? current.toISOString() : current.format(this.config.format));
+    date: {
+      deep: true,
+      handler(value) {
+        if (!value) {
+          return;
         }
-      },
+        let current = moment(value).format(this.config.format);
+        if (this.emitIso) {
+          current = moment(value).toISOString();
+        }
+        this.$emit('input', current);
+      }
+    },
     dataFormat: {
       immediate: true,
       handler() {
@@ -93,26 +95,6 @@ export default {
         this.date = moment(this.value).tz(this.config.timeZone);
       }
     },
-    value: {
-        deep:true,
-        handler(value)
-        {
-            //this.date = moment(value).tz(this.config.timeZone);
-        }
-    },
-  },
-  methods: {
-    setDate(date) {
-      const currentDate = moment(this.date).tz(this.config.timeZone);
-      const newDate = moment.tz(moment(date).format('YYYY-MM-DDTHH:mm:ss'), 'YYYY-MM-DDTHH:mm:ss', this.config.timeZone);
-
-      if (newDate.isSame(currentDate, 'minute')) {
-        return;
-      }
-
-      this.date = newDate;
-      this.$emit('input', this.emitIso ? newDate.toISOString() : newDate.format(this.config.format));
-    }
   },
 };
 </script>


### PR DESCRIPTION
Related to ProcessMaker/modeler#960. This cleans up dead code that was left in the date picker and handles cases where an empty or null value is passed to the date picker.