### PR TITLE
Stored date times are loaded with one day less

### DIFF
--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -78,6 +78,8 @@ export default {
         if (!value) {
           return;
         }
+
+        moment.tz.setDefault(this.config.timeZone);
         let current = moment(value).format(this.config.format);
         if (this.emitIso) {
           current = moment(value).toISOString();
@@ -92,9 +94,16 @@ export default {
           ? getUserDateTimeFormat()
           : getUserDateFormat();
 
+        moment.tz.setDefault(this.config.timeZone);
         this.date = moment(this.value).tz(this.config.timeZone);
       }
     },
+    value: {
+      immediate:true,
+      handler: function handler(_value) {
+          this.showClear=true;
+      }
+    }
   },
 };
 </script>

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -2,12 +2,12 @@
     <div class="form-group position-relative">
         <label v-uni-for="name">{{label}}</label>
         <date-picker
-          v-model="date"
-          :config="config"
-          :value="date"
-          :disabled="disabled"
-          :placeholder="placeholder"
-          :data-test="dataTest"
+                :config="config"
+                :value="date"
+                @input="setDate"
+                :disabled="disabled"
+                :placeholder="placeholder"
+                :data-test="dataTest"
         />
         <div v-if="(validator && validator.errorCount) || error" class="invalid-feedback d-block">
             <div v-for="(error, index) in validator.errors.get(this.name)" :key="index">{{error}}</div>
@@ -18,103 +18,131 @@
 </template>
 
 <script>
-import {createUniqIdsMixin} from 'vue-uniq-ids';
-import ValidationMixin from './mixins/validation';
-import DataFormatMixin from "./mixins/DataFormat";
-import datePicker from 'vue-bootstrap-datetimepicker';
-import 'pc-bootstrap4-datetimepicker/build/css/bootstrap-datetimepicker.css';
-import moment from 'moment-timezone';
-import {getLang, getTimezone, getUserDateFormat, getUserDateTimeFormat} from '../dateUtils';
+    import {createUniqIdsMixin} from 'vue-uniq-ids';
+    import ValidationMixin from './mixins/validation';
+    import DataFormatMixin from "./mixins/DataFormat";
+    import datePicker from 'vue-bootstrap-datetimepicker';
+    import 'pc-bootstrap4-datetimepicker/build/css/bootstrap-datetimepicker.css';
+    import moment from 'moment-timezone';
+    import {getLang, getTimezone, getUserDateFormat, getUserDateTimeFormat} from '../dateUtils';
 
-const uniqIdsMixin = createUniqIdsMixin();
-const datetimeStdFormat = 'YYYY-MM-DDTHH:mm:ssZZ';
+    const uniqIdsMixin = createUniqIdsMixin();
+    const datetimeStdFormat = 'YYYY-MM-DDTHH:mm:ssZZ';
 
-export default {
-  mixins: [uniqIdsMixin, ValidationMixin, DataFormatMixin],
-  components: {
-    datePicker
-  },
-  props: {
-    emitIso: Boolean,
-    name: String,
-    placeholder: String,
-    label: String,
-    error: String,
-    helper: String,
-    dataFormat: String,
-    value: String,
-    inputClass: {type: [String, Array, Object], default: 'form-control'},
-    dataTest: String,
-    disabled: null,
-  },
-  data() {
-    return {
-      date: null,
-      config: {
-        format: datetimeStdFormat,
-        timeZone: getTimezone(),
-        locale: getLang(),
-        useCurrent: false,
-        showClear: true,
-        showClose: true,
-        icons: {
-          time: 'far fa-clock',
-          date: 'far fa-calendar',
-          up: 'fas fa-arrow-up',
-          down: 'fas fa-arrow-down',
-          previous: 'fas fa-chevron-left',
-          next: 'fas fa-chevron-right',
-          today: 'fas fa-calendar-check',
-          clear: 'far fa-trash-alt',
-          close: 'far fa-times-circle'
-        }
-      },
-    }
-  },
-  watch: {
-      date: {
-          deep:true,
-        handler(value) {
-            let current = value;
-            if (typeof value === 'object') {
-            } else if (typeof value === 'string') {
-                current = moment(value);
+    export default {
+        mixins: [uniqIdsMixin, ValidationMixin, DataFormatMixin],
+        components: {
+            datePicker
+        },
+        props: {
+            emitIso: Boolean,
+            name: String,
+            placeholder: String,
+            label: String,
+            error: String,
+            helper: String,
+            dataFormat: String,
+            value: String,
+            inputClass: {type: [String, Array, Object], default: 'form-control'},
+            dataTest: String,
+            disabled: null,
+        },
+        data() {
+            return {
+                date: null,
+                config: {
+                    format: datetimeStdFormat,
+                    timeZone: getTimezone(),
+                    locale: getLang(),
+                    useCurrent: false,
+                    showClear: true,
+                    showClose: true,
+                    icons: {
+                        time: 'far fa-clock',
+                        date: 'far fa-calendar',
+                        up: 'fas fa-arrow-up',
+                        down: 'fas fa-arrow-down',
+                        previous: 'fas fa-chevron-left',
+                        next: 'fas fa-chevron-right',
+                        today: 'fas fa-calendar-check',
+                        clear: 'far fa-trash-alt',
+                        close: 'far fa-times-circle'
+                    }
+                },
             }
-            this.$emit('input', this.emitIso ? current.toISOString() : current.format(this.config.format));
-        }
-      },
-    dataFormat: {
-      immediate: true,
-      handler() {
-        this.config.format = this.dataFormat === 'datetime'
-          ? getUserDateTimeFormat()
-          : getUserDateFormat();
+        },
+        watch: {
+            dataFormat: {
+                immediate: true,
+                handler() {
+                    this.config.format = this.dataFormat === 'datetime' ? Object(dateUtils["d" /* getUserDateTimeFormat */])() : Object(dateUtils["c" /* getUserDateFormat */])();
 
-        this.date = moment(this.value).tz(this.config.timeZone);
-      }
-    },
-    value: {
-        deep:true,
-        handler(value)
-        {
-            //this.date = moment(value).tz(this.config.timeZone);
-        }
-    },
-  },
-  methods: {
-    setDate(date) {
-      const currentDate = moment(this.date).tz(this.config.timeZone);
-      const newDate = moment.tz(moment(date).format('YYYY-MM-DDTHH:mm:ss'), 'YYYY-MM-DDTHH:mm:ss', this.config.timeZone);
+                    if (typeof (this.value) === 'undefined') {
+                        var newDate = moment();
+                        this.emitir(newDate);
+                    }
+                    else {
+                        this.setDate(this.value);
+                    }                }
+            },
+            value: {
+                immediate: false,
+                handler: function handler(_value) {
+                    if (typeof (_value) === 'undefined') {
+                        var newDate = moment();
+                        this.emitir(newDate);
+                    }
+                    else {
+                        this.setDate(_value);
+                    }
+                }
+            }        },
+        methods: {
+            emitir: function (fecha) {
+                var porEmitir = this.emitIso ? fecha.toISOString() : fecha.format(this.config.format);
+                console.log('>>Emitiendo: ', porEmitir);
+                this.$emit('input', porEmitir);
+            },
+            fechita: function(fecha) {
+                console.log('fechita', fecha);
+                moment_timezone_default().tz.setDefault(this.config.timeZone);
+                if (fecha) {
+                    return moment_timezone_default()(fecha, this.config.format).tz(this.config.timeZone);
+                }
+                else {
+                    return moment_timezone_default()().tz(this.config.timeZone);
+                }
+            },
+            setDate(date) {
+                console.log('----------');
+                console.log('** setDate: ', date);
+                if (typeof (date) === 'undefined') {
+                    var newDate = moment();
+                    this.emitir(newDate);
+                    return;
+                }
+                moment_timezone_default().tz.setDefault(this.config.timeZone);
+                var currentDate = moment_timezone_default()(this.date, this.config.format).tz(this.config.timeZone);
+                var newDate = moment_timezone_default.a.tz(moment_timezone_default()(date, this.config.format).format('YYYY-MM-DDTHH:mm:ss'), 'YYYY-MM-DDTHH:mm:ss', this.config.timeZone);
 
-      if (newDate.isSame(currentDate, 'minute')) {
-        return;
-      }
+                console.log('currentDate: ' + currentDate.toString());
+                console.log('newDate: ' + newDate.toString());
+                //console.log('moment(date):' + moment_timezone_default()(date).toString());
+                //console.log('moment(date, ZH)' + moment_timezone_default()(date, this.config.timeZone).toString());
+                //console.log('moment(date, LP)' + moment_timezone_default()(date, 'America/La_Paz').toString());
 
-      this.date = newDate;
-      this.$emit('input', this.emitIso ? newDate.toISOString() : newDate.format(this.config.format));
-    }
-  },
-};
+                if (newDate.isSame(currentDate, 'minute') || !newDate.isValid()) {
+                    this.emitir(currentDate);
+                    return;
+                }
+
+                this.date = newDate;
+                console.log('Emitiendo: '+ newDate.format(this.config.format));
+                console.log('----------');
+                this.emitir(newDate);
+            }
+        },
+    };
 </script>
 
 <style>

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -79,28 +79,36 @@
                             ? getUserDateTimeFormat()
                             : getUserDateFormat();
 
+                    // console.log('watch-dataFormat: ', this.value);
                     this.emitOrSetDate(this.value);
                 }
             },
             value(_value) {
+                // console.log('****Watch-value: ', _value);
+                //this.$emit('input', 'poto');
                 this.emitOrSetDate(_value);
             }
         },
         methods: {
             emitOrSetDate(date) {
+                // console.log('__emitOrSetDate', date )
                 moment.tz.setDefault(this.config.timeZone);
                 if (typeof (date) === 'undefined') {
+                    // console.log('____ por emit', moment().toString());
                     this.emitDate(moment());
                 }
                 else {
+                    // console.log('____ por set date ', date);
                     this.setDate(date);
                 }
             },
             emitDate: function (date) {
+                // console.log('______ emitDate ', date.toString());
                 var toEmit = this.emitIso ? date.toISOString() : date.format(this.config.format);
                 this.$emit('input', toEmit);
             },
             dateInUserTimeZone: function(dateString) {
+                // console.log('______ dateInUserTimeZone ', dateString);
                 moment.tz.setDefault(this.config.timeZone);
                 if (dateString) {
                     return moment(dateString, this.config.format).tz(this.config.timeZone);
@@ -110,7 +118,9 @@
                 }
             },
             setDate(date) {
+                // console.log('______ setDate ', date);
                 if (typeof (date) === 'undefined') {
+                    // console.log('_________ por typeof undefined ', date);
                     this.emitDate(moment());
                     return;
                 }

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -75,71 +75,56 @@
             dataFormat: {
                 immediate: true,
                 handler() {
-                    this.config.format = this.dataFormat === 'datetime' ? Object(dateUtils["d" /* getUserDateTimeFormat */])() : Object(dateUtils["c" /* getUserDateFormat */])();
+                    this.config.format = this.dataFormat === 'datetime'
+                            ? getUserDateTimeFormat()
+                            : getUserDateFormat();
 
-                    if (typeof (this.value) === 'undefined') {
-                        var newDate = moment();
-                        this.emitir(newDate);
-                    }
-                    else {
-                        this.setDate(this.value);
-                    }                }
-            },
-            value: {
-                immediate: false,
-                handler: function handler(_value) {
-                    if (typeof (_value) === 'undefined') {
-                        var newDate = moment();
-                        this.emitir(newDate);
-                    }
-                    else {
-                        this.setDate(_value);
-                    }
+                    this.emitOrSetDate(this.value);
                 }
-            }        },
-        methods: {
-            emitir: function (fecha) {
-                var porEmitir = this.emitIso ? fecha.toISOString() : fecha.format(this.config.format);
-                console.log('>>Emitiendo: ', porEmitir);
-                this.$emit('input', porEmitir);
             },
-            fechita: function(fecha) {
-                console.log('fechita', fecha);
-                moment_timezone_default().tz.setDefault(this.config.timeZone);
-                if (fecha) {
-                    return moment_timezone_default()(fecha, this.config.format).tz(this.config.timeZone);
+            value(_value) {
+              this.emitOrSetDate(_value);
+            }
+        },
+        methods: {
+            emitOrSetDate(date) {
+                moment.tz.setDefault(this.config.timeZone);
+                if (typeof (date) === 'undefined') {
+                    this.emitDate(moment());
                 }
                 else {
-                    return moment_timezone_default()().tz(this.config.timeZone);
+                    this.setDate(date);
+                }
+            },
+            emitDate: function (date) {
+                var toEmit = this.emitIso ? date.toISOString() : date.format(this.config.format);
+                this.$emit('input', toEmit);
+            },
+            dateInUserTimeZone: function(dateString) {
+                moment.tz.setDefault(this.config.timeZone);
+                if (dateString) {
+                    return moment(dateString, this.config.format).tz(this.config.timeZone);
+                }
+                else {
+                    return moment.tz(this.config.timeZone);
                 }
             },
             setDate(date) {
-                console.log('----------');
-                console.log('** setDate: ', date);
                 if (typeof (date) === 'undefined') {
-                    var newDate = moment();
-                    this.emitir(newDate);
+                    this.emitDate(moment());
                     return;
                 }
-                moment_timezone_default().tz.setDefault(this.config.timeZone);
-                var currentDate = moment_timezone_default()(this.date, this.config.format).tz(this.config.timeZone);
-                var newDate = moment_timezone_default.a.tz(moment_timezone_default()(date, this.config.format).format('YYYY-MM-DDTHH:mm:ss'), 'YYYY-MM-DDTHH:mm:ss', this.config.timeZone);
-
-                console.log('currentDate: ' + currentDate.toString());
-                console.log('newDate: ' + newDate.toString());
-                //console.log('moment(date):' + moment_timezone_default()(date).toString());
-                //console.log('moment(date, ZH)' + moment_timezone_default()(date, this.config.timeZone).toString());
-                //console.log('moment(date, LP)' + moment_timezone_default()(date, 'America/La_Paz').toString());
+                moment.tz.setDefault(this.config.timeZone);
+                var currentDate = moment(this.date, this.config.format).tz(this.config.timeZone);
+                var newDate = moment.tz(moment(date, this.config.format).format('YYYY-MM-DDTHH:mm:ss'), 'YYYY-MM-DDTHH:mm:ss', this.config.timeZone);
 
                 if (newDate.isSame(currentDate, 'minute') || !newDate.isValid()) {
-                    this.emitir(currentDate);
+                    this.emitDate(currentDate);
                     return;
                 }
 
                 this.date = newDate;
-                console.log('Emitiendo: '+ newDate.format(this.config.format));
-                console.log('----------');
-                this.emitir(newDate);
+                this.emitDate(newDate);
             }
         },
     };

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -22,7 +22,7 @@
     import ValidationMixin from './mixins/validation';
     import DataFormatMixin from "./mixins/DataFormat";
     import datePicker from 'vue-bootstrap-datetimepicker';
-    //import 'pc-bootstrap4-datetimepicker/build/css/bootstrap-datetimepicker.css';
+    import 'pc-bootstrap4-datetimepicker/build/css/bootstrap-datetimepicker.css';
     import moment from 'moment-timezone';
     import {getLang, getTimezone, getUserDateFormat, getUserDateTimeFormat} from '../dateUtils';
 
@@ -78,37 +78,28 @@
                     this.config.format = this.dataFormat === 'datetime'
                             ? getUserDateTimeFormat()
                             : getUserDateFormat();
-
-                    // console.log('watch-dataFormat: ', this.value);
                     this.emitOrSetDate(this.value);
                 }
             },
             value(_value) {
-                // console.log('****Watch-value: ', _value);
-                //this.$emit('input', 'poto');
                 this.emitOrSetDate(_value);
             }
         },
         methods: {
             emitOrSetDate(date) {
-                // console.log('__emitOrSetDate', date )
                 moment.tz.setDefault(this.config.timeZone);
                 if (typeof (date) === 'undefined') {
-                    // console.log('____ por emit', moment().toString());
                     this.emitDate(moment());
                 }
                 else {
-                    // console.log('____ por set date ', date);
                     this.setDate(date);
                 }
             },
             emitDate: function (date) {
-                // console.log('______ emitDate ', date.toString());
                 var toEmit = this.emitIso ? date.toISOString() : date.format(this.config.format);
                 this.$emit('input', toEmit);
             },
             dateInUserTimeZone: function(dateString) {
-                // console.log('______ dateInUserTimeZone ', dateString);
                 moment.tz.setDefault(this.config.timeZone);
                 if (dateString) {
                     return moment(dateString, this.config.format).tz(this.config.timeZone);
@@ -118,9 +109,7 @@
                 }
             },
             setDate(date) {
-                // console.log('______ setDate ', date);
                 if (typeof (date) === 'undefined') {
-                    // console.log('_________ por typeof undefined ', date);
                     this.emitDate(moment());
                     return;
                 }

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -22,7 +22,7 @@
     import ValidationMixin from './mixins/validation';
     import DataFormatMixin from "./mixins/DataFormat";
     import datePicker from 'vue-bootstrap-datetimepicker';
-    import 'pc-bootstrap4-datetimepicker/build/css/bootstrap-datetimepicker.css';
+    //import 'pc-bootstrap4-datetimepicker/build/css/bootstrap-datetimepicker.css';
     import moment from 'moment-timezone';
     import {getLang, getTimezone, getUserDateFormat, getUserDateTimeFormat} from '../dateUtils';
 
@@ -83,7 +83,7 @@
                 }
             },
             value(_value) {
-              this.emitOrSetDate(_value);
+                this.emitOrSetDate(_value);
             }
         },
         methods: {
@@ -115,8 +115,23 @@
                     return;
                 }
                 moment.tz.setDefault(this.config.timeZone);
-                var currentDate = moment(this.date, this.config.format).tz(this.config.timeZone);
+                var currentDate = this.date
+                                    ? moment(this.date, this.config.format).tz(this.config.timeZone)
+                                    : moment();
                 var newDate = moment.tz(moment(date, this.config.format).format('YYYY-MM-DDTHH:mm:ss'), 'YYYY-MM-DDTHH:mm:ss', this.config.timeZone);
+
+                if (!currentDate.isValid()) {
+                    currentDate = moment(this.date).tz(this.config.timeZone);
+                }
+
+                if (!newDate.isValid()) {
+                    newDate = moment.tz(moment(date).format('YYYY-MM-DDTHH:mm:ss'), 'YYYY-MM-DDTHH:mm:ss', this.config.timeZone);
+                }
+
+                if (!newDate.isValid || !currentDate.isValid()) {
+                    this.emitDate(moment());
+                    return;
+                }
 
                 if (newDate.isSame(currentDate, 'minute') || !newDate.isValid()) {
                     this.emitDate(currentDate);

--- a/tests/unit/FormDatePicker.spec.js
+++ b/tests/unit/FormDatePicker.spec.js
@@ -6,16 +6,16 @@ describe('FormDatePicker', () => {
   const factory = (propsData) => {
     return shallowMount(FormDatePicker, { propsData });
   }
+  
+  it('renders the component', () => {
+    const wrapper = factory({ dataFormat });
+    expect(wrapper.html()).toContain('date-picker-stub');
 
-  // it('renders the component', () => {
-  //   const wrapper = factory({ dataFormat });
-  //   expect(wrapper.html()).toContain('date-picker-stub');
-  //
-  //   const value = wrapper.find('date-picker-stub').vm.value;
-  //   const dateDisplayed = new Date(value).setUTCMilliseconds(0);
-  //   const today = new Date().setUTCMilliseconds(0);
-  //   expect(dateDisplayed).toBe(today);
-  // });
+    const value = wrapper.find('date-picker-stub').vm.value;
+    const dateDisplayed = new Date(value).setUTCMilliseconds(0);
+    const today = new Date().setUTCMilliseconds(0);
+    expect(dateDisplayed).toBe(today);
+  });
 
   it('should emit a value on mount', () => {
     const wrapper = factory({ dataFormat });
@@ -26,7 +26,7 @@ describe('FormDatePicker', () => {
     const wrapper = factory({ dataFormat });
     const value = '10/20/2020';
 
-    wrapper.setProps({ value });
+    wrapper.find('date-picker-stub').setProps({ value });
     expect(wrapper.emitted().input[1]).toEqual([value]);
   });
 
@@ -44,36 +44,35 @@ describe('FormDatePicker', () => {
   it('should render all configured props', () => {
     const nameText = 'birthdate';
     const labelText = 'Enter Your Birthday';
-    const placeholderText = 'Input a Date Time';
+    const placeholderText = 'MM/DD/YYYY';
     const helperText = 'This is some text';
+    const errorText = 'This field has an error';
     const readOnly = true;
     const wrapper = factory({
       name: nameText,
       label: labelText,
       placeholder: placeholderText,
-      dataFormat: 'date',
       helper: helperText,
+      error: errorText,
       disabled: readOnly,
       validation: 'required',
       value: ''
     });
 
-
-    expect(wrapper.html()).toContain(labelText);
-    expect(wrapper.vm.placeholder).toBe(placeholderText);
-    // expect(wrapper.find('.invalid-feedback').text()).toContain(helperText);
-    // expect(wrapper.find('.invalid-feedback').text()).toContain(errorText);
+    expect(wrapper.html()).toContain(label);
+    expect(wrapper.vm.placeholder).toBe(placeholder);
+    expect(wrapper.find('.invalid-feedback').text()).toContain(helperText);
+    expect(wrapper.find('.invalid-feedback').text()).toContain(errorText);
     expect(wrapper.vm.disabled).toBe(true);
-    expect(wrapper.vm.name).toBe(nameText);
-    expect(wrapper.vm._data.config.format).toBe('MM/DD/YYYY');
+    expect(wrapper.find('date-picker-stub').vm.props.config.format).toBe('MM/DD/YYYY');
 
+    expect(wrapper.name()).toBe(nameText);
+    expect(wrapper.vm.dataFormat).toBe(dataType);
 
     wrapper.setProps({
       dataFormat: 'datetime'
     });
-
-    wrapper.setData({ prueba: 'pruebita' });
-    expect(wrapper.vm._data.config.format).toBe('MM/DD/YYYY h:mm A');
+    expect(wrapper.find('date-picker-stub').vm.props.config.format).toBe('MM/DD/YYYY h:mm A');
   });
 
   it('displays validation error messages when the field is invalid', () => {
@@ -81,79 +80,76 @@ describe('FormDatePicker', () => {
     const errorText = 'This field has an error';
     const wrapper = factory({
       name: 'FormDatePicker',
-      error: '',
+      error: errorText,
       validation: 'required',
       value: ''
     });
 
-    wrapper.setProps({errorCount: 1, validator:{errors: {errors: { FormDatePicker: [errorText]} }}});
-
-    console.log('-*-*-*- HTML:', wrapper.html())
-    expect(wrapper.classes('is-invalid')).toBe(true);
-    // expect(wrapper.find('.invalid-feedback').isVisible()).toBe(true);
-    // expect(wrapper.find('.invalid-feedback').text()).toContain(requiredText);
-    // expect(wrapper.find('.invalid-feedback').text()).toContain(errorText);
+    expect(wrapper.find('date-picker-stub').classes('is-invalid')).toBe(true);
+    expect(wrapper.find('.invalid-feedback').isVisible()).toBe(true);
+    expect(wrapper.find('.invalid-feedback').text()).toContain(requiredText);
+    expect(wrapper.find('.invalid-feedback').text()).toContain(errorText);
   });
 
-  // it('removes the validation error messages when the field is valid.', () => {
-  //   const errorText = 'This field has an error';
-  //   const value = 'bar';
-  //   const wrapper = factory({
-  //     name: 'FormDatePicker',
-  //     error: errorText,
-  //     validation: 'required',
-  //     value: '10/20/2020',
-  //   });
-  //
-  //   expect(wrapper.find('.invalid-feedback').exists()).toBe(false);
-  //   expect(wrapper.find('date-picker-stub').classes('is-invalid')).toBe(false);
-  // });
-  //
-  // it('runs validation for invalid date formats', () => {
-  //   const wrapper = factory({dateFormat});
-  //
-  //   wrapper.setProps({value: '2020/24/10'});
-  //   expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(false);
-  //   expect(wrapper.find('.invalid-feedback').exists()).toBe(true);
-  //   expect(wrapper.find('.invalid-feedback').isVisible()).toBe(true);
-  //   expect(wrapper.find('.invalid-feedback').text()).toBe(invalidText);
-  //   expect(wrapper.find('.is-invalid').exists()).toBe(true);
-  //
-  //   wrapper.setProps({value: '10/24/2020 10:00 AM'});
-  //   expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(false);
-  //   expect(wrapper.find('.invalid-feedback').exists()).toBe(true);
-  //   expect(wrapper.find('.invalid-feedback').isVisible()).toBe(true);
-  //   expect(wrapper.find('.invalid-feedback').text()).toBe(invalidText);
-  //   expect(wrapper.find('.is-invalid').exists()).toBe(true);
-  //
-  //   wrapper.setProps({value: '10/24/2020'});
-  //   expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(true);
-  //   expect(wrapper.find('.invalid-feedback').exists()).toBe(false);
-  //   expect(wrapper.find('.invalid-feedback').isVisible()).toBe(false);
-  //   expect(wrapper.find('.is-invalid').exists()).toBe(false);
-  // });
-  //
-  // it('runs validation for invalid datetime formats', () => {
-  //   let dataFormat = 'datetime';
-  //   const wrapper = factor({dataFormat});
-  //
-  //   wrapper.setProps({value: '2020/24/10 10:00 AM'});
-  //   expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(false);
-  //   expect(wrapper.find('.invalid-feedback').exists()).toBe(true);
-  //   expect(wrapper.find('.invalid-feedback').isVisible()).toBe(true);
-  //   expect(wrapper.find('.invalid-feedback').text()).toBe(invalidText);
-  //   expect(wrapper.find('.is-invalid').exists()).toBe(true);
-  //
-  //   wrapper.setProps({value: '10/24/2020'});
-  //   expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(true);
-  //   expect(wrapper.find('.invalid-feedback').exists()).toBe(false);
-  //   expect(wrapper.find('.invalid-feedback').isVisible()).toBe(false);
-  //   expect(wrapper.find('.is-invalid').exists()).toBe(false);
-  //
-  //   wrapper.setProps({value: '10/24/2020 10:00 AM'});
-  //   expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(true);
-  //   expect(wrapper.find('.invalid-feedback').exists()).toBe(false);
-  //   expect(wrapper.find('.invalid-feedback').isVisible()).toBe(false);
-  //   expect(wrapper.find('.is-invalid').exists()).toBe(false);
-  // });
+  it('removes the validation error messages when the field is valid.', () => {
+    const errorText = 'This field has an error';
+    const value = 'bar';
+    const wrapper = factory({
+      name: 'FormDatePicker',
+      error: errorText,
+      validation: 'required',
+      value: '10/20/2020',
+    });
+    
+    expect(wrapper.find('.invalid-feedback').exists()).toBe(false);
+    expect(wrapper.find('date-picker-stub').classes('is-invalid')).toBe(false);
+  });
+
+  it('runs validation for invalid date formats', () => {
+    const wrapper = factory({dateFormat});
+
+    wrapper.setProps({value: '2020/24/10'});
+    expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(false);
+    expect(wrapper.find('.invalid-feedback').exists()).toBe(true);
+    expect(wrapper.find('.invalid-feedback').isVisible()).toBe(true);
+    expect(wrapper.find('.invalid-feedback').text()).toBe(invalidText);
+    expect(wrapper.find('.is-invalid').exists()).toBe(true);
+
+    wrapper.setProps({value: '10/24/2020 10:00 AM'});
+    expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(false);
+    expect(wrapper.find('.invalid-feedback').exists()).toBe(true);
+    expect(wrapper.find('.invalid-feedback').isVisible()).toBe(true);
+    expect(wrapper.find('.invalid-feedback').text()).toBe(invalidText);
+    expect(wrapper.find('.is-invalid').exists()).toBe(true);
+
+    wrapper.setProps({value: '10/24/2020'});
+    expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(true);
+    expect(wrapper.find('.invalid-feedback').exists()).toBe(false);
+    expect(wrapper.find('.invalid-feedback').isVisible()).toBe(false);
+    expect(wrapper.find('.is-invalid').exists()).toBe(false);
+  });
+
+  it('runs validation for invalid datetime formats', () => {
+    let dataFormat = 'datetime';
+    const wrapper = factor({dataFormat});
+
+    wrapper.setProps({value: '2020/24/10 10:00 AM'});
+    expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(false);
+    expect(wrapper.find('.invalid-feedback').exists()).toBe(true);
+    expect(wrapper.find('.invalid-feedback').isVisible()).toBe(true);
+    expect(wrapper.find('.invalid-feedback').text()).toBe(invalidText);
+    expect(wrapper.find('.is-invalid').exists()).toBe(true);
+
+    wrapper.setProps({value: '10/24/2020'});
+    expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(true);
+    expect(wrapper.find('.invalid-feedback').exists()).toBe(false);
+    expect(wrapper.find('.invalid-feedback').isVisible()).toBe(false);
+    expect(wrapper.find('.is-invalid').exists()).toBe(false);
+
+    wrapper.setProps({value: '10/24/2020 10:00 AM'});
+    expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(true);
+    expect(wrapper.find('.invalid-feedback').exists()).toBe(false);
+    expect(wrapper.find('.invalid-feedback').isVisible()).toBe(false);
+    expect(wrapper.find('.is-invalid').exists()).toBe(false);
+  });
 });

--- a/tests/unit/FormDatePicker.spec.js
+++ b/tests/unit/FormDatePicker.spec.js
@@ -6,16 +6,16 @@ describe('FormDatePicker', () => {
   const factory = (propsData) => {
     return shallowMount(FormDatePicker, { propsData });
   }
-  
-  it('renders the component', () => {
-    const wrapper = factory({ dataFormat });
-    expect(wrapper.html()).toContain('date-picker-stub');
 
-    const value = wrapper.find('date-picker-stub').vm.value;
-    const dateDisplayed = new Date(value).setUTCMilliseconds(0);
-    const today = new Date().setUTCMilliseconds(0);
-    expect(dateDisplayed).toBe(today);
-  });
+  // it('renders the component', () => {
+  //   const wrapper = factory({ dataFormat });
+  //   expect(wrapper.html()).toContain('date-picker-stub');
+  //
+  //   const value = wrapper.find('date-picker-stub').vm.value;
+  //   const dateDisplayed = new Date(value).setUTCMilliseconds(0);
+  //   const today = new Date().setUTCMilliseconds(0);
+  //   expect(dateDisplayed).toBe(today);
+  // });
 
   it('should emit a value on mount', () => {
     const wrapper = factory({ dataFormat });
@@ -26,7 +26,7 @@ describe('FormDatePicker', () => {
     const wrapper = factory({ dataFormat });
     const value = '10/20/2020';
 
-    wrapper.find('date-picker-stub').setProps({ value });
+    wrapper.setProps({ value });
     expect(wrapper.emitted().input[1]).toEqual([value]);
   });
 
@@ -44,35 +44,36 @@ describe('FormDatePicker', () => {
   it('should render all configured props', () => {
     const nameText = 'birthdate';
     const labelText = 'Enter Your Birthday';
-    const placeholderText = 'MM/DD/YYYY';
+    const placeholderText = 'Input a Date Time';
     const helperText = 'This is some text';
-    const errorText = 'This field has an error';
     const readOnly = true;
     const wrapper = factory({
       name: nameText,
       label: labelText,
       placeholder: placeholderText,
+      dataFormat: 'date',
       helper: helperText,
-      error: errorText,
       disabled: readOnly,
       validation: 'required',
       value: ''
     });
 
-    expect(wrapper.html()).toContain(label);
-    expect(wrapper.vm.placeholder).toBe(placeholder);
-    expect(wrapper.find('.invalid-feedback').text()).toContain(helperText);
-    expect(wrapper.find('.invalid-feedback').text()).toContain(errorText);
-    expect(wrapper.vm.disabled).toBe(true);
-    expect(wrapper.find('date-picker-stub').vm.props.config.format).toBe('MM/DD/YYYY');
 
-    expect(wrapper.name()).toBe(nameText);
-    expect(wrapper.vm.dataFormat).toBe(dataType);
+    expect(wrapper.html()).toContain(labelText);
+    expect(wrapper.vm.placeholder).toBe(placeholderText);
+    // expect(wrapper.find('.invalid-feedback').text()).toContain(helperText);
+    // expect(wrapper.find('.invalid-feedback').text()).toContain(errorText);
+    expect(wrapper.vm.disabled).toBe(true);
+    expect(wrapper.vm.name).toBe(nameText);
+    expect(wrapper.vm._data.config.format).toBe('MM/DD/YYYY');
+
 
     wrapper.setProps({
       dataFormat: 'datetime'
     });
-    expect(wrapper.find('date-picker-stub').vm.props.config.format).toBe('MM/DD/YYYY h:mm A');
+
+    wrapper.setData({ prueba: 'pruebita' });
+    expect(wrapper.vm._data.config.format).toBe('MM/DD/YYYY h:mm A');
   });
 
   it('displays validation error messages when the field is invalid', () => {
@@ -80,76 +81,79 @@ describe('FormDatePicker', () => {
     const errorText = 'This field has an error';
     const wrapper = factory({
       name: 'FormDatePicker',
-      error: errorText,
+      error: '',
       validation: 'required',
       value: ''
     });
 
-    expect(wrapper.find('date-picker-stub').classes('is-invalid')).toBe(true);
-    expect(wrapper.find('.invalid-feedback').isVisible()).toBe(true);
-    expect(wrapper.find('.invalid-feedback').text()).toContain(requiredText);
-    expect(wrapper.find('.invalid-feedback').text()).toContain(errorText);
+    wrapper.setProps({errorCount: 1, validator:{errors: {errors: { FormDatePicker: [errorText]} }}});
+
+    console.log('-*-*-*- HTML:', wrapper.html())
+    expect(wrapper.classes('is-invalid')).toBe(true);
+    // expect(wrapper.find('.invalid-feedback').isVisible()).toBe(true);
+    // expect(wrapper.find('.invalid-feedback').text()).toContain(requiredText);
+    // expect(wrapper.find('.invalid-feedback').text()).toContain(errorText);
   });
 
-  it('removes the validation error messages when the field is valid.', () => {
-    const errorText = 'This field has an error';
-    const value = 'bar';
-    const wrapper = factory({
-      name: 'FormDatePicker',
-      error: errorText,
-      validation: 'required',
-      value: '10/20/2020',
-    });
-    
-    expect(wrapper.find('.invalid-feedback').exists()).toBe(false);
-    expect(wrapper.find('date-picker-stub').classes('is-invalid')).toBe(false);
-  });
-
-  it('runs validation for invalid date formats', () => {
-    const wrapper = factory({dateFormat});
-
-    wrapper.setProps({value: '2020/24/10'});
-    expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(false);
-    expect(wrapper.find('.invalid-feedback').exists()).toBe(true);
-    expect(wrapper.find('.invalid-feedback').isVisible()).toBe(true);
-    expect(wrapper.find('.invalid-feedback').text()).toBe(invalidText);
-    expect(wrapper.find('.is-invalid').exists()).toBe(true);
-
-    wrapper.setProps({value: '10/24/2020 10:00 AM'});
-    expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(false);
-    expect(wrapper.find('.invalid-feedback').exists()).toBe(true);
-    expect(wrapper.find('.invalid-feedback').isVisible()).toBe(true);
-    expect(wrapper.find('.invalid-feedback').text()).toBe(invalidText);
-    expect(wrapper.find('.is-invalid').exists()).toBe(true);
-
-    wrapper.setProps({value: '10/24/2020'});
-    expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(true);
-    expect(wrapper.find('.invalid-feedback').exists()).toBe(false);
-    expect(wrapper.find('.invalid-feedback').isVisible()).toBe(false);
-    expect(wrapper.find('.is-invalid').exists()).toBe(false);
-  });
-
-  it('runs validation for invalid datetime formats', () => {
-    let dataFormat = 'datetime';
-    const wrapper = factor({dataFormat});
-
-    wrapper.setProps({value: '2020/24/10 10:00 AM'});
-    expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(false);
-    expect(wrapper.find('.invalid-feedback').exists()).toBe(true);
-    expect(wrapper.find('.invalid-feedback').isVisible()).toBe(true);
-    expect(wrapper.find('.invalid-feedback').text()).toBe(invalidText);
-    expect(wrapper.find('.is-invalid').exists()).toBe(true);
-
-    wrapper.setProps({value: '10/24/2020'});
-    expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(true);
-    expect(wrapper.find('.invalid-feedback').exists()).toBe(false);
-    expect(wrapper.find('.invalid-feedback').isVisible()).toBe(false);
-    expect(wrapper.find('.is-invalid').exists()).toBe(false);
-
-    wrapper.setProps({value: '10/24/2020 10:00 AM'});
-    expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(true);
-    expect(wrapper.find('.invalid-feedback').exists()).toBe(false);
-    expect(wrapper.find('.invalid-feedback').isVisible()).toBe(false);
-    expect(wrapper.find('.is-invalid').exists()).toBe(false);
-  });
+  // it('removes the validation error messages when the field is valid.', () => {
+  //   const errorText = 'This field has an error';
+  //   const value = 'bar';
+  //   const wrapper = factory({
+  //     name: 'FormDatePicker',
+  //     error: errorText,
+  //     validation: 'required',
+  //     value: '10/20/2020',
+  //   });
+  //
+  //   expect(wrapper.find('.invalid-feedback').exists()).toBe(false);
+  //   expect(wrapper.find('date-picker-stub').classes('is-invalid')).toBe(false);
+  // });
+  //
+  // it('runs validation for invalid date formats', () => {
+  //   const wrapper = factory({dateFormat});
+  //
+  //   wrapper.setProps({value: '2020/24/10'});
+  //   expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(false);
+  //   expect(wrapper.find('.invalid-feedback').exists()).toBe(true);
+  //   expect(wrapper.find('.invalid-feedback').isVisible()).toBe(true);
+  //   expect(wrapper.find('.invalid-feedback').text()).toBe(invalidText);
+  //   expect(wrapper.find('.is-invalid').exists()).toBe(true);
+  //
+  //   wrapper.setProps({value: '10/24/2020 10:00 AM'});
+  //   expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(false);
+  //   expect(wrapper.find('.invalid-feedback').exists()).toBe(true);
+  //   expect(wrapper.find('.invalid-feedback').isVisible()).toBe(true);
+  //   expect(wrapper.find('.invalid-feedback').text()).toBe(invalidText);
+  //   expect(wrapper.find('.is-invalid').exists()).toBe(true);
+  //
+  //   wrapper.setProps({value: '10/24/2020'});
+  //   expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(true);
+  //   expect(wrapper.find('.invalid-feedback').exists()).toBe(false);
+  //   expect(wrapper.find('.invalid-feedback').isVisible()).toBe(false);
+  //   expect(wrapper.find('.is-invalid').exists()).toBe(false);
+  // });
+  //
+  // it('runs validation for invalid datetime formats', () => {
+  //   let dataFormat = 'datetime';
+  //   const wrapper = factor({dataFormat});
+  //
+  //   wrapper.setProps({value: '2020/24/10 10:00 AM'});
+  //   expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(false);
+  //   expect(wrapper.find('.invalid-feedback').exists()).toBe(true);
+  //   expect(wrapper.find('.invalid-feedback').isVisible()).toBe(true);
+  //   expect(wrapper.find('.invalid-feedback').text()).toBe(invalidText);
+  //   expect(wrapper.find('.is-invalid').exists()).toBe(true);
+  //
+  //   wrapper.setProps({value: '10/24/2020'});
+  //   expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(true);
+  //   expect(wrapper.find('.invalid-feedback').exists()).toBe(false);
+  //   expect(wrapper.find('.invalid-feedback').isVisible()).toBe(false);
+  //   expect(wrapper.find('.is-invalid').exists()).toBe(false);
+  //
+  //   wrapper.setProps({value: '10/24/2020 10:00 AM'});
+  //   expect(wrapper.find('date-picker-stub').vm.value.isValid()).toBe(true);
+  //   expect(wrapper.find('.invalid-feedback').exists()).toBe(false);
+  //   expect(wrapper.find('.invalid-feedback').isVisible()).toBe(false);
+  //   expect(wrapper.find('.is-invalid').exists()).toBe(false);
+  // });
 });


### PR DESCRIPTION
Resolves #142 

- A possible bug in moment.js caused the use of the Browser's timezone instead of the configured default (that in our application is set to the users's configured time zone). The code was refactored to use always the default zone.
- When the control has an empty date the current datetime is used.