### PR TITLE
Fix date formatting

### DIFF
--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -1,19 +1,19 @@
 <template>
-    <div class="form-group position-relative">
-        <label v-uni-for="name">{{label}}</label>
-        <date-picker
-              v-model="date"
-              :config="config"
-              :disabled="disabled"
-              :placeholder="placeholder"
-              :data-test="dataTest"
-        />
-        <div v-if="(validator && validator.errorCount) || error" class="invalid-feedback d-block">
-            <div v-for="(error, index) in validator.errors.get(this.name)" :key="index">{{error}}</div>
-            <div v-if="error">{{error}}</div>
-        </div>
-        <small v-if="helper" class="form-text text-muted">{{helper}}</small>
+  <div class="form-group position-relative">
+    <label v-uni-for="name">{{label}}</label>
+    <date-picker
+      v-model="date"
+      :config="config"
+      :disabled="disabled"
+      :placeholder="placeholder"
+      :data-test="dataTest"
+    />
+    <div v-if="(validator && validator.errorCount) || error" class="invalid-feedback d-block">
+      <div v-for="(error, index) in validator.errors.get(this.name)" :key="index">{{error}}</div>
+      <div v-if="error">{{error}}</div>
     </div>
+    <small v-if="helper" class="form-text text-muted">{{helper}}</small>
+  </div>
 </template>
 
 <script>
@@ -90,7 +90,7 @@ export default {
       }
     },
     value: {
-      immediate:true,
+      immediate: true,
       handler() {
         this.config.showClear = true;
         this.emitValueFromDate();
@@ -115,7 +115,7 @@ export default {
       console.log('emitValueFromDate', value);
     },
     generateDate() {
-      let date  = moment.utc(this.value, this.config.format);
+      let date = moment.utc(this.value, this.config.format);
 
       if (!date.isValid()) {
         date = moment();
@@ -132,7 +132,7 @@ export default {
 </script>
 
 <style>
-    .inspector-container .bootstrap-datetimepicker-widget.dropdown-menu {
-        font-size: 11px;
-    }
+  .inspector-container .bootstrap-datetimepicker-widget.dropdown-menu {
+    font-size: 11px;
+  }
 </style>

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -77,8 +77,14 @@ export default {
           return;
         }
 
-        this.$emit('input', this.generateDate(date).toISOString());
+        this.$emit('input', this.generateDate(moment(date, this.config.format)).toISOString());
       },
+    },
+    value(value) {
+      const date = this.generateDate(value);
+      if (date.toISOString() !== moment(this.date, this.config.format).toISOString()) {
+        this.date = date;
+      }
     },
     dataFormat: {
       immediate: true,
@@ -93,7 +99,7 @@ export default {
   },
   methods: {
     generateDate(value = this.value) {
-      let date = moment(value, this.config.format);
+      let date = moment(value);
 
       if (!date.isValid()) {
         date = moment();

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -35,7 +35,6 @@ export default {
     datePicker
   },
   props: {
-    emitIso: Boolean,
     name: String,
     placeholder: String,
     label: String,
@@ -74,7 +73,11 @@ export default {
     date: {
       deep: true,
       handler(date) {
-        this.emitValueFromDate(moment(date, this.config.format));
+        if (!this.date) {
+          return;
+        }
+
+        this.$emit('input', this.generateDate(date).toISOString());
       },
     },
     dataFormat: {
@@ -85,37 +88,12 @@ export default {
           : getUserDateFormat();
 
         this.date = this.generateDate();
-        // eslint-disable-next-line no-console
-        console.log('Setting date to', this.date.toISOString(), 'from', this.value);
       }
     },
-    value: {
-      immediate: true,
-      handler() {
-        this.config.showClear = true;
-        this.emitValueFromDate();
-      }
-    }
   },
   methods: {
-    emitValueFromDate(date = this.generateDate()) {
-      let value = date.utc().format(this.config.format);
-
-      if (this.emitIso) {
-        value = date.toISOString();
-      }
-
-      if (value === this.value) {
-        return;
-      }
-
-      this.$emit('input', value);
-
-      // eslint-disable-next-line no-console
-      console.log('emitValueFromDate', value);
-    },
-    generateDate() {
-      let date = moment.utc(this.value, this.config.format);
+    generateDate(value = this.value) {
+      let date = moment(value, this.config.format);
 
       if (!date.isValid()) {
         date = moment();

--- a/src/components/mixins/DataFormat.js
+++ b/src/components/mixins/DataFormat.js
@@ -1,5 +1,5 @@
 import Validator from 'validatorjs';
-import { isValidDate, getUserDateFormat } from '../../dateUtils';
+import moment from 'moment-timezone';
 
 // To include another language in the Validator with variable processmaker
 let globalObject = typeof window === 'undefined'
@@ -9,8 +9,6 @@ let globalObject = typeof window === 'undefined'
 if (globalObject.ProcessMaker && globalObject.ProcessMaker.user && globalObject.ProcessMaker.user.lang) {
   Validator.useLang(globalObject.ProcessMaker.user.lang);
 }
-
-Validator.register('dateFormat', isValidDate, `The :attribute is not a valid date with format ${getUserDateFormat()}`);
 
 export default {
   props: {
@@ -57,7 +55,7 @@ export default {
         'boolean': 'boolean',
         'string': 'string',
         'datetime': 'date',
-        'date': 'dateFormat',
+        'date': 'date',
         'float': 'regex:/^[+-]?\\d+(\\.\\d+)?$/',
         'currency': 'regex:/^[+-]?\\d+(\\.\\d+)?$/',
         'array': 'array',
@@ -92,10 +90,8 @@ export default {
           newValue = parseFloat(newValue);
           break;
         case 'date':
-          newValue = newValue.toString();
-          break;
         case 'datetime':
-          newValue = newValue.toString();
+          newValue = moment(newValue).toISOString();
           break;
         case 'int':
           newValue = parseInt(newValue);


### PR DESCRIPTION
This PR is required as part of the fix for https://github.com/ProcessMaker/screen-builder/issues/498.

There's still plenty of room for refactor in the datepicker component, but the changes in this PR accomplish the following;
 * Ensure the date (or datetime) is displayed in the user's selected format.
 * When the "date" data type is selected, ensure it refers to the start of the day in the user's timezone.
 * `this.date` will be the formatted date/datetime string, but `this.value` will always be the full ISO date string.
 * `this.date` is updated when `this.value` changes (and vice versa, a new ISO date string will be emitted when the date changes).