### PR TITLE
Show the field label in the validation messages.

### DIFF
--- a/src/components/mixins/validation.js
+++ b/src/components/mixins/validation.js
@@ -52,6 +52,7 @@ export default {
                     [fieldName]: this.validation
                 }
                 this.validator = new Validator(data, rules, this.validationMessages ? this.validationMessages : null)
+                this.validator.setAttributeNames({ name: this.label });
                 // Validation will not run until you call passes/fails on it
                 this.validator.passes()
             } else {


### PR DESCRIPTION
<h2>Changes</h2>
Uses the field's label instead of the variable name for the validation messages.

![Screen Shot 2020-01-28 at 3 24 50 PM](https://user-images.githubusercontent.com/52755494/73314354-80f25180-41e2-11ea-9cd2-0a75371e40e2.png)

closes [screen-builder/#520](https://github.com/ProcessMaker/screen-builder/issues/520)
