### PR TITLE
Revert validation changes

### DIFF
--- a/src/components/mixins/validation.js
+++ b/src/components/mixins/validation.js
@@ -48,22 +48,8 @@ export default {
             if (this.validation) {
                 let fieldName = this.validationField ? this.validationField : this.name;
                 let data = this.validationData ? this.validationData : {[fieldName]: this.value}
-                let validationRules = '';
-
-                if (typeof this.validation !== 'string' && this.validation.length) {
-                    let rules = [];
-
-                    this.validation.forEach(configs => {
-                        rules.push(configs.value);
-                    });
-
-                    validationRules = rules;
-                } else {
-                    validationRules = this.validation;
-                }
-
                 let rules = {
-                    [fieldName]: validationRules
+                    [fieldName]: this.validation
                 }
                 this.validator = new Validator(data, rules, this.validationMessages ? this.validationMessages : null)
                 // Validation will not run until you call passes/fails on it

--- a/src/components/mixins/validation.js
+++ b/src/components/mixins/validation.js
@@ -49,14 +49,14 @@ export default {
                 let fieldName = this.validationField ? this.validationField : this.name;
                 let data = this.validationData ? this.validationData : {[fieldName]: this.value}
                 let validationRules = '';
-               
+
                 if (typeof this.validation !== 'string' && this.validation.length) {
                     let rules = [];
 
                     this.validation.forEach(configs => {
-                        rules.push(configs.value); 
+                        rules.push(configs.value);
                     });
-            
+
                     validationRules = rules;
                 } else {
                     validationRules = this.validation;
@@ -66,7 +66,6 @@ export default {
                     [fieldName]: validationRules
                 }
                 this.validator = new Validator(data, rules, this.validationMessages ? this.validationMessages : null)
-                this.validator.setAttributeNames({ name: this.label });
                 // Validation will not run until you call passes/fails on it
                 this.validator.passes();
             } else {


### PR DESCRIPTION
This PR reverts the changes to validation introduced in https://github.com/ProcessMaker/vue-form-elements/pull/157 and https://github.com/ProcessMaker/vue-form-elements/pull/158.

These changes seemed to be causing issues when testing in modeler. The following console error was being consistently thrown:
<img width="681" alt="Screen Shot 2020-01-31 at 9 46 36 AM" src="https://user-images.githubusercontent.com/7561061/73558397-18dd7e80-4421-11ea-87ba-f5d32e3f3c91.png">

Testing these reverted changes in modeler, the error is no longer showing up, all test pass, and a manual test of the app doesn't reveal any obvious bugs.