### PR TITLE
Fix Validations for Mulitselect

### DIFF
--- a/src/components/FormMultiSelect.vue
+++ b/src/components/FormMultiSelect.vue
@@ -6,10 +6,11 @@
       v-bind="$attrs"
       v-on="$listeners"
       v-uni-id="name"
+      :value="value"
       :name="name"
       :track-by="optionValue"
       :label="optionContent"
-      :class="{'border border-danger':error}"
+      :class="classList"
       :placeholder="placeholder ? placeholder : $t('type here to search')"
     >
       <template slot="noResult">
@@ -43,6 +44,7 @@
     },
     mixins: [uniqIdsMixin, ValidationMixin],
     props: [
+      'value',
       'optionValue',
       'optionContent',
       'label',
@@ -55,11 +57,11 @@
     computed: {
       classList() {
         return {
-          'is-invalid': (this.validator && this.validator.errorCount) || this.error,
+          'is-invalid border border-danger': (this.validator && this.validator.errorCount) || this.error,
           [this.controlClass]: !!this.controlClass
         }
       },
-    },
+    }
   }
 </script>
 


### PR DESCRIPTION
<h2>Changes</h2>
Fixes the UI validation to display the global `.is-invalid` styling class when there is an error attribute configured but also a validation error.

Ref [Processmaker/#2843](https://github.com/ProcessMaker/processmaker/issues/2843)