### PR TITLE
Fix Vue Multiselect from emitting object when using single select

### DIFF
--- a/src/components/FormPlainMultiSelect.vue
+++ b/src/components/FormPlainMultiSelect.vue
@@ -83,39 +83,14 @@
           let emit = [];
           if (this.multiple) {
             value.map(item => {
-              emit.push(this.onlyKey ? item[this.optionValue] : item);
+              emit.push(item[this.optionValue]);
             });
           } else {
-            emit = this.onlyKey ? value[0][this.optionValue] : value;
+            emit = this.onlyKey ? value[this.optionValue]: value;
           }
           this.$emit("input", emit);
         }
       },
-      value: {
-        immediate: true,
-        handler(value, oldValue) {
-          if (Array.isArray(value)) {
-            let objectList = [];
-            value.forEach(item => {
-              let selection = item;
-              if (typeof item === 'object') {
-                selection = item[this.optionValue]
-              }
-              let foundOption = this.options.find(option => get(option, this.optionValue) === selection);
-              if (foundOption) {
-                if (Array.isArray(this.selected)) {
-                  this.selected.push(foundOption);
-                }
-                else {
-                  this.selected = foundOption;
-                }
-              }
-            })
-          } else {
-            this.selected = this.options.find(option => get(option, this.optionValue) === value)
-          }
-        }
-      }
     },
   }
 </script>

--- a/src/components/FormPlainMultiSelect.vue
+++ b/src/components/FormPlainMultiSelect.vue
@@ -74,40 +74,105 @@
       }
     },
     watch: {
-      selected: {
-        handler(value, oldValue) {
-          if (JSON.stringify(value) === JSON.stringify(oldValue)) {
-            return;
+      value: {
+        immediate: true,
+        handler(value) {
+          if (this.multiple && this.onlyKey) {
+            if (this.valueOriginForKeysOnly(value) === 'VueMultiSelect') {
+              let emit = [];
+              value.map(item => {
+                emit.push(item[this.optionValue]);
+              });
+              this.$emit('input', emit);
+            }
+
+            if (this.valueOriginForKeysOnly(value) === 'DirectSet') {
+              let selectedArray = [];
+              value.forEach(item => {
+                let foundOption = this.options.find( option => JSON.stringify(option.value) === JSON.stringify(item));
+                if (foundOption) {
+                  selectedArray.push(foundOption);
+                }
+              })
+              this.selected = selectedArray;
+            }
           }
 
-          let emit = [];
-          if (this.multiple) {
-            value.map(item => {
-              emit.push(item[this.optionValue]);
-            });
-          } else {
-            emit = this.onlyKey ? value[this.optionValue]: value;
+          if (this.multiple && !this.onlyKey) {
+            if (this.valueOriginForObjectsOnly(value) === 'VueMultiSelect') {
+              let emit = [];
+              value.map(item => {
+                emit.push(item.value);
+              });
+              this.$emit('input', emit);
+            }
+
+            if (this.valueOriginForObjectsOnly(value) === 'DirectSet') {
+              let selectedArray = [];
+              value.forEach(item => {
+                let foundOption = this.options.find( option => JSON.stringify(option.value) === JSON.stringify(item));
+                if (foundOption) {
+                  selectedArray.push(foundOption);
+                }
+              })
+              this.selected = selectedArray;
+            }
           }
-          this.$emit("input", emit);
+
+          if (!this.multiple && this.onlyKey) {
+            if (this.valueOriginForKeysOnly(value) === 'VueMultiSelect') {
+              this.$emit('input', value[0][this.optionValue]);
+            }
+
+            if (this.valueOriginForKeysOnly(value) === 'DirectSet') {
+              let selectedArray = [];
+              value.forEach(item => {
+                let foundOption = this.options.find( option => JSON.stringify(option.value) === JSON.stringify(item));
+                if (foundOption) {
+                  selectedArray.push(foundOption);
+                }
+              })
+              this.selected = selectedArray.length > 0 ? selectedArray[0] : [];
+            }
+          }
+
+          if (!this.multiple && !this.onlyKey) {
+            if (this.valueOriginForObjectsOnly(value) === 'VueMultiSelect') {
+              this.$emit('input', value[0].value);
+            }
+
+            if (this.valueOriginForObjectsOnly(value) === 'DirectSet') {
+              let selectedArray = [];
+              value.forEach(item => {
+                let foundOption = this.options.find( option => JSON.stringify(option.value) === JSON.stringify(item));
+                if (foundOption) {
+                  selectedArray.push(foundOption);
+                }
+              })
+              this.selected = selectedArray.length > 0 ? selectedArray[0] : [];
+            }
+          }
+
         }
-      },
-      value: {	
-        immediate: true,	
-        handler(value, oldValue) {
-          if (Array.isArray(value)) {	
-            value.forEach(item => {	
-              let selection = item;	
-              let foundOption = this.options.find(option => get(option, this.optionValue) === selection);	
-              if (foundOption) {	
-                if (!Array.isArray(this.selected)) {
-                  this.selected = foundOption;	
-                }	
-              }	
-            })	
-          } else {
-            this.selected = this.options.find(option => get(option, this.optionValue) === value)	
-          }	
-        }	
+      }
+    },
+    methods: {
+        valueOriginForObjectsOnly: function (value) {
+          if (typeof value === 'undefined' || value === null || !Array.isArray(value) || value.length <= 0) {
+            return 'None';
+          }
+
+          let firstVal = value[0];
+          return (typeof firstVal[this.optionValue] === 'object' ? 'VueMultiSelect' : 'DirectSet');
+        },
+
+        valueOriginForKeysOnly: function (value) {
+          if (typeof value === 'undefined' || value === null || !Array.isArray(value) || value.length <= 0) {
+            return 'None';
+          }
+
+          let firstVal = value[0];
+          return (typeof firstVal === 'object' ? 'VueMultiSelect' : 'DirectSet');
       }
     }
   }

--- a/src/components/FormPlainMultiSelect.vue
+++ b/src/components/FormPlainMultiSelect.vue
@@ -91,7 +91,25 @@
           this.$emit("input", emit);
         }
       },
-    },
+      value: {	
+        immediate: true,	
+        handler(value, oldValue) {
+          if (Array.isArray(value)) {	
+            value.forEach(item => {	
+              let selection = item;	
+              let foundOption = this.options.find(option => get(option, this.optionValue) === selection);	
+              if (foundOption) {	
+                if (!Array.isArray(this.selected)) {
+                  this.selected = foundOption;	
+                }	
+              }	
+            })	
+          } else {
+            this.selected = this.options.find(option => get(option, this.optionValue) === value)	
+          }	
+        }	
+      }
+    }
   }
 </script>
 

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -13,13 +13,13 @@
       :show-labels="false"
       :options="optionsList"
       :class="classList"
-      :only-key="onlyKey"      
+      :only-key="onlyKey"
       :multiple="allowMultiSelect"
     >
     </form-plain-multi-select>
 
     <div v-if="options.renderAs === 'checkbox' && allowMultiSelect">
-      <div :class="divClass" :key="option.value" v-for="option in optionsList">
+      <div :class="divClass" :key="typeof option.value == 'object' ? option.value[optionKey] : option.value" v-for="option in optionsList">
         <input
           v-bind="$attrs"
           :class="inputClass"
@@ -36,7 +36,7 @@
     </div>
 
     <div v-if="options.renderAs === 'checkbox' && !allowMultiSelect">
-      <div :class="divClass" :key="option.value" v-for="option in optionsList">
+      <div :class="divClass" :key="typeof option.value == 'object' ? option.value[optionKey] : option.value" v-for="option in optionsList">
         <input
           v-bind="$attrs"
           type="radio"
@@ -201,7 +201,7 @@
               this.onlyKey = false;
             }
             this.selectedOptions = Array.isArray(this.value) ? this.value : [this.value]
-          } 
+          }
           else {
             this.selectedOptions = Array.isArray(this.value) ? this.value[0] : [this.value]
           }
@@ -274,7 +274,7 @@
           value: (option[key || 'value']).toString(),
           content: (option[value || 'content']).toString(),
         })
-        if (jsonData) {          
+        if (jsonData) {
           try {
             options = JSON.parse(jsonData)
               .map(convertToSelectOptions)
@@ -291,7 +291,7 @@
         if (dataName) {
           if (this.options.valueTypeReturned === null) {
             return;
-          } 
+          }
 
           if (this.options.valueTypeReturned === 'single') {
             try {
@@ -302,8 +302,8 @@
             } catch (error) {
               /* Ignore error */
             }
-          } 
-          
+          }
+
           if (this.options.valueTypeReturned === 'object') {
             const convertObjectToSelectOptions = option => ({
               value: option,
@@ -316,7 +316,7 @@
             } catch(error) {
               /* Ignore error */
             }
-          } 
+          }
         }
 
       },

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -15,7 +15,6 @@
       :class="classList"
       :only-key="onlyKey"      
       :multiple="allowMultiSelect"
-      @input="sendSelectedOptions"
     >
     </form-plain-multi-select>
 
@@ -103,6 +102,7 @@
         renderAs: 'dropdown',
         allowMultiSelect: false,
         optionsList: [],
+        onlyKey: true,
         debounceGetDataSource: _.debounce((selectedDataSource, selectedEndPoint, dataName, currentValue, key, value,
                                            selOptions) => {
           let options = [];
@@ -155,7 +155,6 @@
               /* Ignore error */
             });
         }, 750),
-        onlyKey: true,
       };
     },
     watch: {
@@ -214,7 +213,6 @@
     mounted() {
       this.renderAs = this.options.renderAs;
       this.allowMultiSelect = this.options.allowMultiSelect;
-      this.onlyKey = this.options.onlyKey;
       this.valueTypeReturned = this.options.valueTypeReturned;
       this.optionsFromDataSource();
 

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -196,10 +196,9 @@
             return;
           }
 
+          this.onlyKey = !(this.options.valueTypeReturned === 'object');
+
           if (this.options.allowMultiSelect) {
-            if (this.options.valueTypeReturned === 'object') {
-              this.onlyKey = false;
-            }
             this.selectedOptions = Array.isArray(this.value) ? this.value : [this.value]
           }
           else {


### PR DESCRIPTION
<h2>Changes</h2>

1. Fixes the vue multiselect value emitting an object  ```{"value": "foo","content":"Foo"}```
on a single select by passing only the object's value when the property `onlyKey` is set to `true`
2. Fixes the multiselect option values being returned multiple times when selecting more than one option.

<h4>Video of Select List using Provided Data</h4>

https://www.loom.com/share/4f802b819c69488dbf34590dad11b1c8

<h4>Video of Select List using Request Data</h4>

https://www.loom.com/share/6121bc6432be4ad88e69d228f5d4c4b9


closes #171 