### PR TITLE
Rich Text: Render HTML from Variable

### DIFF
--- a/src/components/FormHtmlEditor.vue
+++ b/src/components/FormHtmlEditor.vue
@@ -68,12 +68,15 @@ export default {
       }
     
       try {
-        if (!this.renderVarHtml) {
-          return Mustache.render(this.content, {...this.customFunctions, ...this.validationData});
+        if (this.renderVarHtml) {
+          return Mustache.render(this.variableToRender, {...this.customFunctions, ...this.validationData});  
         }
-        return Mustache.render(this.variableToRender, {...this.customFunctions, ...this.validationData});
+        return Mustache.render(this.content, {...this.customFunctions, ...this.validationData});
       } catch (error) {
-        return this.content; this.renderVarName;
+        if (this.renderVarHtml) {
+          return this.renderVarName;
+        }
+        return this.content;
       }
     }
   },

--- a/src/components/FormHtmlEditor.vue
+++ b/src/components/FormHtmlEditor.vue
@@ -45,6 +45,7 @@ export default {
     'content',
     'validationData',
     'label',
+    'renderVarHtml',
     // 'value'
   ],
   computed:{
@@ -62,10 +63,17 @@ export default {
         return this.content;
       }
 
+      if (this.renderVarHtml) {
+        this.variableToRender = `{${this.content}}`;
+      }
+    
       try {
-        return Mustache.render(this.content, {...this.customFunctions, ...this.validationData});
+        if (!this.renderVarHtml) {
+          return Mustache.render(this.content, {...this.customFunctions, ...this.validationData});
+        }
+        return Mustache.render(this.variableToRender, {...this.customFunctions, ...this.validationData});
       } catch (error) {
-        return this.content;
+        return this.content; this.renderVarName;
       }
     }
   },
@@ -86,6 +94,7 @@ export default {
         relative_urls: false,
         remove_script_host: false,
       },
+      variableToRender: null,
     }
   }
 }


### PR DESCRIPTION
<h2>Changes</h2>

Adds conditional to check if the user enabled the `Render Html from Variable` option. When enabled, we automatically want to set the mustache variable to the triple `{{{var_name}}}` mustache syntax to unescape HTML.

**Dependency**
https://github.com/ProcessMaker/screen-builder/pull/677