### PR TITLE
Screen Builder: Fix Date Mask Errors

### DIFF
--- a/src/components/mixins/DataFormat.js
+++ b/src/components/mixins/DataFormat.js
@@ -10,6 +10,11 @@ if (globalObject.ProcessMaker && globalObject.ProcessMaker.user && globalObject.
   Validator.useLang(globalObject.ProcessMaker.user.lang);
 }
 
+Validator.register('date', function(date) {
+  let checkDate = moment(date);
+  return checkDate.isValid();
+}, 'The :attribute must be a valid date.');
+
 export default {
   props: {
     dataFormat: {


### PR DESCRIPTION
<h2>Changes</h2>

Console errors were due to a bug within the ValidatorJS library. 
https://github.com/skaterdav85/validatorjs/issues/357

This PR registers a custom validation rule for 'Date' as a temporary workaround for the above bug. 

Screen Builder PR: 
https://github.com/ProcessMaker/screen-builder/pull/695
