### PR TITLE
Fix Date Picker console errors

### DIFF
--- a/src/components/mixins/validation.js
+++ b/src/components/mixins/validation.js
@@ -55,6 +55,9 @@ export default {
                     let rules = [];
 
                     this.validation.forEach(configs => {
+                        if (!configs.value) {
+                            return;
+                        }
                         rules.push(configs.value); 
                     });
             

--- a/src/components/mixins/validation.js
+++ b/src/components/mixins/validation.js
@@ -139,7 +139,7 @@ export default {
                 const beforeDate = moment(params).toISOString();
                 
                 return inputDate <= beforeDate;
-            }, 'The :attribute must be equal or after :before_or_equal.');
+            }, 'The :attribute must be equal or before :before_or_equal.');
         }
     }
 }


### PR DESCRIPTION
<h2>Changes</h2>

Console errors were due to the validation running on an empty value. This PR adds a conditional to check if the value has been set before running the validation. 

closes [ProcessMaker/screenbuilder#720](https://github.com/ProcessMaker/screen-builder/issues/720)