### PR TITLE
Fix required_if & required_unless validation of boolean & number values

### DIFF
--- a/src/components/mixins/validation.js
+++ b/src/components/mixins/validation.js
@@ -140,6 +140,52 @@ export default {
                 
                 return inputDate <= beforeDate;
             }, 'The :attribute must be equal or before :before_or_equal.');
-        }
+
+            Validator.register('required_if', function(val, req, attribute) {
+                if (typeof req === 'string') {
+                    req = req.split(',');
+                }
+                
+                let inputtedValue = this.validator._objectPath(this.validator.input, req[0]);
+            
+                switch (typeof inputtedValue) {
+                    case 'boolean':
+                    case 'number':
+                        if (inputtedValue.toString() == req[1]) {
+                            return this.validator.getRule('required').validate(val);
+                        }
+                        break;
+                    default:
+                        if (inputtedValue == req[1]) {
+                            return this.validator.getRule('required').validate(val);
+                        }
+                        break;
+                }
+                return true;
+            }, 'The :attribute field is required.');
+
+            Validator.register('required_unless', function(val, req, attribute) {
+                if (typeof req === 'string') {
+                    req = req.split(',');
+                }
+                
+                let inputtedValue = this.validator._objectPath(this.validator.input, req[0]);
+            
+                switch (typeof inputtedValue) {
+                    case 'boolean':
+                    case 'number':
+                        if (inputtedValue.toString() !== req[1]) {
+                            return this.validator.getRule('required').validate(val);
+                        }
+                        break;
+                    default:
+                        if (inputtedValue !== req[1]) {
+                            return this.validator.getRule('required').validate(val);
+                        }
+                        break;
+                }
+                return true;
+            }, 'The :attribute field is required.');
+        },
     }
 }


### PR DESCRIPTION
<h2>Changes</h2>

This PR registers a custom `required_if` & `required_unless` validation to allow boolean & number values to be properly validated. 

Open issue In ValidatorJS
https://github.com/skaterdav85/validatorjs/issues/211

https://www.loom.com/share/d94e9537b9e04415a3fb96c082637d4f

<h2>To Test</h2>

1. Add a new checkbox & input control.
2. Configure the input controls validation to `required_if` or `required_unless`, input the checkbox variable name and set the value to `true`.
3. Preview the form and select the checkbox

**Expected Behavior**
Validation errors appear for the input control when the checkbox value is `true`.

closes https://github.com/ProcessMaker/screen-builder/issues/724