### PR TITLE
All checkboxes are set to checked if initiallyChecked is undefined

### DIFF
--- a/src/components/FormCheckbox.vue
+++ b/src/components/FormCheckbox.vue
@@ -48,7 +48,7 @@ export default {
   computed: {
     isChecked() {
       // if control's value is not set, use the initiallyChecked configuration
-      let initCheck = new Boolean(this.initiallyChecked)
+      let initCheck = (new Boolean(this.initiallyChecked)) == true;
       if (typeof(this.checked) == 'undefined') {
         this.$emit('change', initCheck);
         return initCheck;


### PR DESCRIPTION
The problem was caused because the value emitted was a Boolean object. A pure true/false value is sent now.

**Note**: this PR complements the solution to
 https://github.com/ProcessMaker/screen-builder/issues/723