### PR TITLE
Rich Text does not render HTML from a variable in an Email screen

### DIFF
--- a/src/components/FormHtmlEditor.vue
+++ b/src/components/FormHtmlEditor.vue
@@ -63,13 +63,13 @@ export default {
         return this.content;
       }
 
-      if (this.renderVarHtml) {
-        this.variableToRender = `{${this.content}}`;
-      }
-    
       try {
         if (this.renderVarHtml) {
-          return Mustache.render(this.variableToRender, {...this.customFunctions, ...this.validationData});  
+          let escape = Mustache.escape;
+          Mustache.escape = function(text) {return text;};
+          let render = Mustache.render(this.content, {...this.customFunctions, ...this.validationData});
+          Mustache.escape = escape;
+          return render;
         }
         return Mustache.render(this.content, {...this.customFunctions, ...this.validationData});
       } catch (error) {
@@ -97,7 +97,6 @@ export default {
         relative_urls: false,
         remove_script_host: false,
       },
-      variableToRender: null,
     }
   }
 }


### PR DESCRIPTION
Fixed https://processmaker.atlassian.net/browse/FOUR-1837

switch to two curly braces when rendering html from variable.