### PR TITLE
FOUR-1804: When select list si configured in a screen, it boots me out of the editor

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -87,6 +87,7 @@
     ],
     data() {
       return {
+        apiClient: ProcessMaker.apiClient.create(),
         selectListOptions: [],
         doDebounce: _.debounce(options => {
           const selectedEndPoint = options.selectedEndPoint;
@@ -96,13 +97,18 @@
           const value = options.value;
           let opt = [];
 
+          // If no data source has been specified, do not make the api call
+          if(selectedDataSource === null || typeof selectedDataSource === 'undefined' || selectedDataSource.toString().trim().length === 0) {
+            return;
+          }
+
           let dataSourceUrl = '/requests/data_sources/' + selectedDataSource;
           if (typeof this.options.pmqlQuery !== 'undefined' && this.options.pmqlQuery !== '') {
             let pmql = Mustache.render(this.options.pmqlQuery, {data: this.formData});
             dataSourceUrl += '?pmql=' + pmql;
           }
 
-          ProcessMaker.apiClient
+          this.apiClient
               .post(dataSourceUrl, { config: { endpoint: selectedEndPoint, } })
               .then(response => {
                 var list = dataName ? eval('response.data.' + dataName) : response.data;


### PR DESCRIPTION
Resolves [FOUR-1804](https://processmaker.atlassian.net/browse/FOUR-1804)

The problem was that the endpoint called by the data connector returned with status 401 (this happens  if data connector's authentication configurations is wrong). This response is forwarded to the client as the data connector own response status. ProcessMaker.apiClient has an interceptor that redirects to the login when  any response with status 401 arrives. 

To solve the problem a specific client (created from the global ProcessMaker.apiClient) is used. This specific client doesn't use the global interceptor to avoid the browser redirection.
