### PR TITLE
Add v-bind to select-list component

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -13,6 +13,7 @@
       :class="classList"
       :emit-objects="options.valueTypeReturned === 'object'"
       :emit-array="options.allowMultiSelect"
+      v-bind="$attrs"
     >
     </multi-select-view>
 
@@ -24,6 +25,7 @@
         :option-content="optionsValue"
         :options="selectListOptions"
         :emit-objects="options.valueTypeReturned === 'object'"
+        v-bind="$attrs"
       />
     </div>
 
@@ -35,6 +37,7 @@
           :option-content="optionsValue"
           :options="selectListOptions"
           :emit-objects="options.valueTypeReturned === 'object'"
+          v-bind="$attrs"
       />
     </div>
 

--- a/src/components/FormSelectList/CheckboxView.vue
+++ b/src/components/FormSelectList/CheckboxView.vue
@@ -8,6 +8,7 @@
           :name="`${name}`"
           :value="emitObjects ? option : getOptionValue(option)"
           v-model="selected"
+          v-bind="$attrs"
       >
       <label :class="labelClass" v-uni-for="getOptionId(option)">
         {{getOptionContent(option)}}

--- a/src/components/FormSelectList/MultiSelectView.vue
+++ b/src/components/FormSelectList/MultiSelectView.vue
@@ -10,6 +10,7 @@
         :label="optionContent"
         :class="classList"
         :placeholder="placeholder ? placeholder : $t('type here to search')"
+        v-bind="$attrs"
     >
       <template slot="noResult">
         {{ $t('No elements found. Consider changing the search query.') }}

--- a/src/components/FormSelectList/OptionboxView.vue
+++ b/src/components/FormSelectList/OptionboxView.vue
@@ -8,6 +8,7 @@
           :name="`${name}`"
           :value="emitObjects ? option : getOptionValue(option)"
           v-model="selected"
+          v-bind="$attrs"
       >
       <label :class="labelClass" v-uni-for="getOptionId(option)">
         {{getOptionContent(option)}}


### PR DESCRIPTION
v-bind is required to propagate custom properties to select-list controls.
Required to implement cypress tests.
