### PR TITLE
FOUR-1989 Date field blocks the form

### DIFF
--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -132,7 +132,8 @@ export default {
         return;
       }
 
-      const newDate = moment(this.date, this.config.format);
+      const newDate = this.dataFormat === 'date' ? moment.utc(this.date, this.config.format) : moment(this.date, this.config.format);
+
       this.$emit('input', newDate.toISOString());
     },
     value() {

--- a/src/components/mixins/DataFormat.js
+++ b/src/components/mixins/DataFormat.js
@@ -114,7 +114,7 @@ export default {
           break;
         case 'date':
           if (this.componentName === 'FormDatePicker') {
-            newValue = moment(newValue, [getUserDateFormat(), moment.ISO_8601], true).toISOString().split(RegExp('T[0-9]'))[0];
+            newValue = moment.utc(newValue, [getUserDateFormat(), moment.ISO_8601], true).toISOString().split(RegExp('T[0-9]'))[0];
           }
           break;
         case 'datetime':


### PR DESCRIPTION
Resolves [https://processmaker.atlassian.net/browse/FOUR-1989](https://processmaker.atlassian.net/browse/FOUR-1989)

Now, when date-picker format is set to "date" the times are ignored. In this way we avoid a problem that happened when the user's time zone transformed a date 2020-10-14 (in user's machine) to 2020-10-13 UTC because the user time zone was ahead of GMT.