### PR TITLE
Do not escape mustache content in select list

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -117,8 +117,12 @@
                 const suffix = this.attributeParent(value);
                 list.forEach(item => {
                   // if the content has a mustache expression
+                  const escape = Mustache.escape;
+                  Mustache.escape = (t) => t; // Do not escape mustache content
                   let itemContent = (value.indexOf('{{') >= 0) ? Mustache.render(value, item) : (item[value || 'content'] || '').toString();
                   let itemValue = (key.indexOf('{{') >= 0) ? Mustache.render(key, item) : (item[key || 'value'] || '').toString();
+                  Mustache.escape = escape; // Reset mustache to original escape function
+
                   let parsedOption = {};
                   parsedOption[this.optionsKey] = itemValue;
                   parsedOption[this.optionsValue] = itemContent;


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2073

Mustache escapes special characters like `'` and `\` by default. This fix adds a temporary custom escape function to bypass escaping.