### PR TITLE
On update emit select list options

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -131,6 +131,7 @@
                 });
 
                 this.selectListOptions =  opt;
+                this.$root.$emit('selectListOptionsUpdated', this.sendSelectedOptions);
               })
               .catch(err => {
                 /* Ignore error */
@@ -192,7 +193,7 @@
     },
     watch: {
       sourceConfig: { immediate:true, handler() { this.fillSelectListOptions();} },
-      validationData: { immediate:true, handler() { this.fillSelectListOptions();} },
+      validationData: { immediate:true, handler() { console.log('FORM SELECT VALIDATION DATA CHANGED', this.validationData); this.fillSelectListOptions();} },
     },
     computed: {
       validatorErrors() {


### PR DESCRIPTION
<h2>Changes</h2>
Emit the select list options when using a Data Connector as the Data Source for a select list. 

Needed so that the conversational forms can populate UI buttons. 