### PR TITLE
FOUR-2169:  PMQL doesn't show data if we use an screen variable

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -104,13 +104,14 @@
             return;
           }
 
-          let queryParams = {};
+          let dataSourceUrl = '/requests/data_sources/' + selectedDataSource;
           if (typeof this.options.pmqlQuery !== 'undefined' && this.options.pmqlQuery !== '') {
-            queryParams['pmql'] = Mustache.render(this.options.pmqlQuery, {data: this.formData});
+            let pmql = Mustache.render(this.options.pmqlQuery, {data: this.formData});
+            dataSourceUrl += '?pmql=' + pmql;
           }
 
-          const postParams = { config: { endpoint: selectedEndPoint } };
-          this.$dataProvider.executeDataSource(selectedDataSource, postParams, queryParams)
+          this.apiClient
+              .post(dataSourceUrl, { config: { endpoint: selectedEndPoint, } })
               .then(response => {
                 const list = dataName ? eval('response.data.' + dataName) : response.data;
                 const suffix = this.attributeParent(value);

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -106,7 +106,7 @@
 
           let dataSourceUrl = '/requests/data_sources/' + selectedDataSource;
           if (typeof this.options.pmqlQuery !== 'undefined' && this.options.pmqlQuery !== '') {
-            let pmql = Mustache.render(this.options.pmqlQuery, {data: this.validationData});
+            const pmql = Mustache.render(this.options.pmqlQuery, {data: this.validationData});
             dataSourceUrl += '?pmql=' + pmql;
           }
 

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -106,7 +106,7 @@
 
           let dataSourceUrl = '/requests/data_sources/' + selectedDataSource;
           if (typeof this.options.pmqlQuery !== 'undefined' && this.options.pmqlQuery !== '') {
-            let pmql = Mustache.render(this.options.pmqlQuery, {data: this.formData});
+            let pmql = Mustache.render(this.options.pmqlQuery, {data: this.validationData});
             dataSourceUrl += '?pmql=' + pmql;
           }
 


### PR DESCRIPTION
Resolves [https://processmaker.atlassian.net/browse/FOUR-2183](https://processmaker.atlassian.net/browse/FOUR-2183)
Resolves [https://processmaker.atlassian.net/browse/FOUR-2169](https://processmaker.atlassian.net/browse/FOUR-2169)

- Use of dataProvider has been reverted
- Use of validation Data (The form data) for evaluating mustach PMQL data.