### PR TITLE
Explicitly set content_css to false in tinymce config

### DIFF
--- a/src/components/FormTextArea.vue
+++ b/src/components/FormTextArea.vue
@@ -107,6 +107,7 @@ export default {
         plugins: [ 'link', 'lists', 'image'],
         toolbar: 'undo redo | link image pagebreak | styleselect | bold italic forecolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent',
         skin: false,
+        content_css: false,
         relative_urls: false,
         remove_script_host: false,
         init_instance_callback: (editor) => {


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2405

Needed to add content_css: false because of this bug in tinymce: https://github.com/tinymce/tinymce-react/issues/53#issuecomment-467884622