### PR TITLE
Fix how select list emits values to conversational forms

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -135,6 +135,7 @@
                   }
                 });
 
+                this.$root.$emit('selectListOptionsUpdated', opt);
                 this.selectListOptions =  opt;
               })
               .catch(err => {
@@ -199,13 +200,6 @@
           this.fillSelectListOptions();
         }
       },
-      selectListOptions: {
-        immediate: true,
-        deep: true,
-        handler() {
-          this.$root.$emit('selectListOptionsUpdated', this.selectListOptions);
-        }
-      }
     },
     computed: {
       validatorErrors() {


### PR DESCRIPTION
**JIRA Ticket**
https://processmaker.atlassian.net/browse/FOUR-2363

<h2>Changes</h2>

Changes how the `selectListOptionsUpdated` event is emitted for conversational forms. Preventing the event from being emitted when not using a data connector in a select list.

**Dependency PR**
https://github.com/ProcessMaker/package-conversational-forms/pull/11