### PR TITLE
Reboot the editor when the variable name changes

### DIFF
--- a/src/components/FormTextArea.vue
+++ b/src/components/FormTextArea.vue
@@ -38,6 +38,7 @@ import ValidationMixin from './mixins/validation'
 import DataFormatMixin from './mixins/DataFormat';
 import DisplayErrors from './common/DisplayErrors';
 import Editor from './Editor'
+import _ from 'lodash'
 
 const uniqIdsMixin = createUniqIdsMixin();
 
@@ -81,13 +82,18 @@ export default {
         this.setHeight();
       },
       immediate: true,
-    }
+    },
+    name() {
+      this.rebootEditor();
+    },
   },
-  activated() {
-    this.editorActive = true;
-  },
-  deactivated() {
-    this.editorActive = false;
+  created() {
+    this.rebootEditor = _.throttle(() => {
+      this.editorActive = false;
+      this.$nextTick(() => {
+        this.editorActive = true
+      });
+    }, 500);
   },
   methods: {
     setHeight() {


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-2521

The activated and deactivated lifecycle hooks no longer work in SB v2. Instead reboot the editor when the variable name changes as it does between pages (Vue reuses components between pages to save on resources)