### PR TITLE
Fix: Update watcher dependent field value selecting a new value in the "parent" field

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -198,6 +198,16 @@
         parts.pop();
         return parts.join('.');
       },
+      updateWatcherDependentFieldValue(newSelectOptions, oldSelectOptions) {
+        let dataName = this.options.dataName.split('.');
+        // Check to see if the watcher output variable has been loaded.
+        if (this.validationData && this.validationData.hasOwnProperty(dataName[0]) && this.validationData[dataName[0]] !== null) {
+          if (_.isEqual(newSelectOptions, oldSelectOptions)) {
+            return;
+          }
+          this.$emit('input', null);
+        }
+      }
     },
     watch: {
       sourceConfig: {
@@ -214,6 +224,9 @@
           this.fillSelectListOptions();
         }
       },
+      selectListOptions(newValue, oldValue) {
+        this.updateWatcherDependentFieldValue(newValue, oldValue);
+      }
     },
     computed: {
       validatorErrors() {


### PR DESCRIPTION
**Jira Ticket**
https://processmaker.atlassian.net/browse/FOUR-2726

<h2>Changes</h2>

This PR adds a vue watcher to detect when the select list options have changed. It then updates a configured watchers dependent field value when selecting a new value in the "parent" field.

<h2>To Test</h2>

1. Create a screen with two select list controls
2. One select list control populates values dependent on the option selected in the first control. 
3. In the screen preview, select an option in both select list controls. 
4. Change the option selected in the first control so the dependent select list control needs to reload new options. 

**Expected Behavior**

Within the data preview, the previously selected value in the dependent control is updated and the previously selected option within the select list has been cleared. 

**Video**

https://www.loom.com/share/257a829ab01e4122b75e3f0bd90b3a02
