### PR TITLE
Style and default value update for multi select

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@processmaker/vue-form-elements",
-  "version": "0.18.4",
+  "version": "0.18.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@processmaker/vue-form-elements",
-  "version": "0.18.4",
+  "version": "0.18.5",
   "description": "Reusable VueJS Based Form Elements styled with Bootstrap 4",
   "scripts": {
     "serve": "NODE_ENV=standalone vue-cli-service serve",

--- a/src/components/FormSelectList/MultiSelectView.vue
+++ b/src/components/FormSelectList/MultiSelectView.vue
@@ -120,3 +120,9 @@ export default {
 </script>
 
 <style src="vue-multiselect/dist/vue-multiselect.min.css"></style>
+
+<style>
+.form-group .multiselect__tag {
+  min-height: 22px;
+}
+</style>

--- a/src/components/FormSelectList/MultiSelectView.vue
+++ b/src/components/FormSelectList/MultiSelectView.vue
@@ -37,6 +37,11 @@ import ValidationMixin from '../mixins/validation'
 const uniqIdsMixin = createUniqIdsMixin();
 
 export default {
+  mounted() {
+    if (this.value === null && this.emitArray) {
+      this.$emit('input', []);
+    }
+  },
   inheritAttrs: false,
   components: {
     Multiselect


### PR DESCRIPTION
Fixes part of https://processmaker.atlassian.net/browse/FOUR-2848
- Set the minimum height for a multi select element if the value is empty
- Set the default value to an empty array instead of null if it's configured for multiple values