### PR TITLE
FOUR-2964: Select Lists configured with a Data Connector that returns an object value and multiselect enabled does not work

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -285,6 +285,10 @@
           return 'value';
         }
 
+        if (this.options.dataSource && this.options.dataSource === 'dataConnector' && this.options.valueTypeReturned === 'object') {
+          return this.optionsValue;
+        }
+
         const fieldName = this.options.key || 'value';
 
         return this.stripMustache(fieldName);


### PR DESCRIPTION
Fixes [https://processmaker.atlassian.net/browse/FOUR-2964](https://processmaker.atlassian.net/browse/FOUR-2964)

The issue happened when the MultiSelectList used as track value an attribute that wasn't present in the source. To solve this, if SelectList is configured as dropdown and return objects, the content field is used by default to track the list items.