### PR TITLE
Encode pmql query

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -105,7 +105,7 @@
           let dataSourceUrl = '/requests/data_sources/' + selectedDataSource;
           if (typeof this.options.pmqlQuery !== 'undefined' && this.options.pmqlQuery !== '' && this.options.pmqlQuery !== null) {
             const pmql = Mustache.render(this.options.pmqlQuery, {data: this.validationData});
-            dataSourceUrl += '?pmql=' + pmql;
+            dataSourceUrl += '?pmql=' + encodeURIComponent(pmql);
           }
 
           this.apiClient


### PR DESCRIPTION
Fixes: http://tickets.pm4overflow.com/tickets/567

This PR encodes pmql query, so the user could use **&** in the PMQL of a SelectList.

![image](https://user-images.githubusercontent.com/8028650/129365778-9bc79a35-b7f9-4a43-a095-8eff185e4dbd.png)
