### PR TITLE
Ticket 583: Prevent select list from making duplicate requests when PMQL has not changed

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -236,7 +236,10 @@
       sourceConfig: {
         immediate:true,
         deep: true,
-        handler() {
+        handler(newValue,oldValue) {
+          if (_.isEqual(newValue,oldValue)) {
+            return;
+          }
           this.fillSelectListOptions();
         }
       },
@@ -244,7 +247,10 @@
       validationData: {
         immediate:true,
         deep: true,
-        handler() {
+        handler(newValue, oldValue) {
+          if (_.isEqual(newValue,oldValue)) {
+            return;
+          }
           this.fillSelectListOptions();
         }
       },

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -90,6 +90,7 @@
     ],
     data() {
       return {
+        lastRequest: {},
         apiClient: window.ProcessMaker.apiClient.create(),
         selectListOptions: [],
         doDebounce: _.debounce(options => {
@@ -107,6 +108,13 @@
             const pmql = Mustache.render(this.options.pmqlQuery, {data: this.validationData});
             dataSourceUrl += '?pmql=' + encodeURIComponent(pmql);
           }
+
+          // Do not re-run the same request
+          const request = { dataSourceUrl, selectedEndPoint };
+          if (_.isEqual(this.lastRequest, request)) {
+            return;
+          }
+          this.lastRequest = _.cloneDeep(request);
 
           this.apiClient
               .post(dataSourceUrl, { config: { endpoint: selectedEndPoint, } })
@@ -236,10 +244,7 @@
       sourceConfig: {
         immediate:true,
         deep: true,
-        handler(newValue,oldValue) {
-          if (_.isEqual(newValue,oldValue)) {
-            return;
-          }
+        handler() {
           this.fillSelectListOptions();
         }
       },
@@ -247,10 +252,7 @@
       validationData: {
         immediate:true,
         deep: true,
-        handler(newValue, oldValue) {
-          if (_.isEqual(newValue,oldValue)) {
-            return;
-          }
+        handler() {
           this.fillSelectListOptions();
         }
       },


### PR DESCRIPTION
## Changes
- Uses commits intended for a 4.2.x release of VFE from @sanjacornelius and @nolanpro to solve an issue where duplicate requests were being sent by a select list even if the PMQL had not changed

## Tickets
- http://tickets.pm4overflow.com/tickets/583