### PR TITLE
Bundle TinyMCE Icons

### DIFF
--- a/src/components/Editor.js
+++ b/src/components/Editor.js
@@ -6,5 +6,6 @@ import 'tinymce/plugins/lists';
 import 'tinymce/plugins/image';
 import 'tinymce/skins/ui/oxide/skin.min.css';
 import 'tinymce/skins/ui/oxide/content.inline.min.css';
+import 'tinymce/icons/default';
 
 export default Editor;


### PR DESCRIPTION
<h2>Changes</h2>

In TinyMCE 5.3+ the icons have been moved into a separate file. This PR includes the new icon file in our bundle fixing the 'Not Found' errors within the toolbar and failing Rich Text tests.

https://github.com/tinymce/tinymce/issues/5687#issuecomment-631917082

**Before**

![Screen Shot 2021-09-24 at 12 41 32 PM](https://user-images.githubusercontent.com/52755494/134732151-c9129628-b875-4500-9943-0d816c049c09.png)

**After**

![Screen Shot 2021-09-24 at 12 42 04 PM](https://user-images.githubusercontent.com/52755494/134732193-ef8296f5-871c-4d74-bb2c-6a3648866207.png)

