### PR TITLE
Refactor logic that resets the value when options change

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -341,7 +341,6 @@
           return this.value;
         },
         set(val) {
-          console.log('SETTING emit input', val);
           return this.$emit('input', val);
         }
       },

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -232,13 +232,17 @@
 
         return removed ? removed : str;
       },
-      updateWatcherDependentFieldValue(newSelectOptions, oldSelectOptions) {
-        let dataName = this.options.dataName.split('.');
-        // Check to see if the watcher output variable has been loaded.
-        if (this.validationData && this.validationData.hasOwnProperty(dataName[0]) && this.validationData[dataName[0]] !== null) {
-          if (isEqual(newSelectOptions, oldSelectOptions)) {
-            return;
-          }
+      /**
+       * If the options list changes due to a dependant field change, we need to check if
+       * the selected value still exists in the new set of options. If it's gone now, then
+       * set this control's value to null.
+       */
+      updateWatcherDependentFieldValue() {
+        const hasKeyInOptions = this.selectListOptions.find(option => {
+          return _.get(option, this.optionsKey) === this.value;
+        });
+
+        if (!hasKeyInOptions) {
           this.$emit('input', null);
         }
       },
@@ -337,6 +341,7 @@
           return this.value;
         },
         set(val) {
+          console.log('SETTING emit input', val);
           return this.$emit('input', val);
         }
       },


### PR DESCRIPTION
Fixes https://processmaker.atlassian.net/browse/FOUR-4326

## Context

I was able to narrow this down to a specific use case where a select list, using a data source, has a top-level variable name that already exists in the request data. For example:

![image](https://user-images.githubusercontent.com/2546850/141866696-fcd8d5d1-a1c3-45fb-aad6-9d6ecef27d89.png)

![image](https://user-images.githubusercontent.com/2546850/141866873-ae5766e9-ef54-4de3-8d24-3ae3d5602158.png)

When this is the case, the value in the dropdown is not selected when the task loads.

These settings should be completely unrelated however in https://github.com/ProcessMaker/vue-form-elements/pull/249 we check if the first part of the data name exists in the data and if so, we set the control value to null. This was happening when a task loads.

## To reproduce the error

1. Create a screen like this:
 
![image](https://user-images.githubusercontent.com/2546850/141867957-6bf3c214-967e-47b5-aca9-075714b26c79.png)

- The screen should contain a select list that populates from a data source (I used a collection)
- The data options variable should be `response.data`
- The line input should be named the same as the first part of the options variable `response`

2. Create a process like this with the screen above for each task.

![image](https://user-images.githubusercontent.com/2546850/141867590-fcd77d27-38c8-400d-9e08-35e5031c3c1d.png)

3. Run the process and select a value from the select list and fill in something in the input field. Notice that on the next task, the select list does not keep the original selection.

![image](https://user-images.githubusercontent.com/2546850/141868795-3a7d9398-af78-4629-9750-7a0880bf4ecc.png)


## Proposed Solution

According to the original requirements in https://processmaker.atlassian.net/browse/FOUR-2726 we should only need to null out the 2nd field's value if the key no longer exists after the select list options have been updated.

This fix checks if the key is still available for selection after the options list changes. It only sets it to null if the value no longer an option.