### PR TITLE
feat: TICKET-1299

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@processmaker/vue-form-elements",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11265,6 +11265,11 @@
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
       "dev": true
     },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+    },
     "lodash.defaultsdeep": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@processmaker/vue-form-elements",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@processmaker/vue-form-elements",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "Reusable VueJS Based Form Elements styled with Bootstrap 4",
   "scripts": {
     "serve": "NODE_ENV=standalone vue-cli-service serve",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@tinymce/tinymce-vue": "^2.0.0",
     "bootstrap": "^4.2.1",
     "jquery": "^3.3.1",
+    "lodash-es": "^4.17.21",
     "luxon": "^1.11.3",
     "moment": "^2.24.0",
     "moment-timezone": "^0.5.26",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@processmaker/vue-form-elements",
-  "version": "0.14.2",
+  "version": "0.14.3",
   "description": "Reusable VueJS Based Form Elements styled with Bootstrap 4",
   "scripts": {
     "serve": "NODE_ENV=standalone vue-cli-service serve",

--- a/src/components/FormDelayTimeControl.vue
+++ b/src/components/FormDelayTimeControl.vue
@@ -23,7 +23,7 @@
 
 <script>
 import ValidationMixin from './mixins/validation'
-import last from 'lodash/last';
+import {last} from 'lodash-es';
 
 const periodNames = {
   minute: 'minute',
@@ -76,7 +76,7 @@ export default {
   computed: {
     classList(){
       let classList = {
-        'is-invalid': (this.validator && this.validator.errorCount) || this.error, 
+        'is-invalid': (this.validator && this.validator.errorCount) || this.error,
       }
       if(this.controlClass) {
         classList[this.controlClass] = true

--- a/src/components/FormPlainMultiSelect.vue
+++ b/src/components/FormPlainMultiSelect.vue
@@ -32,7 +32,6 @@
   import {createUniqIdsMixin} from 'vue-uniq-ids'
   import ValidationMixin from './mixins/validation'
   import DisplayErrors from './common/DisplayErrors';
-  import {get} from 'lodash';
 
   const uniqIdsMixin = createUniqIdsMixin();
 

--- a/src/components/FormRadioButtonGroup.vue
+++ b/src/components/FormRadioButtonGroup.vue
@@ -26,8 +26,7 @@ import hasDefaultOptionKey from './mixins/hasDefaultOptionKey';
 const uniqIdsMixin = createUniqIdsMixin();
 
 function removeInvalidOptions(option) {
-  return Object.keys(option).includes('value', 'contemnt') &&
-    option.content != null;
+  return Object.keys(option).includes('value') && !!option.content;
 }
 
 export default {

--- a/src/components/FormSelect.vue
+++ b/src/components/FormSelect.vue
@@ -37,8 +37,7 @@ import hasDefaultOptionKey from './mixins/hasDefaultOptionKey';
 const uniqIdsMixin = createUniqIdsMixin()
 
 function removeInvalidOptions(option) {
-  return Object.keys(option).includes('value', 'contemnt') &&
-    option.content != null;
+  return Object.keys(option).includes('value') && !!option.content;
 }
 
 export default {

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -66,6 +66,7 @@
   import DataFormatMixin from './mixins/DataFormat';
   import FormPlainMultiSelect from "./FormPlainMultiSelect";
   import Mustache from "mustache";
+	import {debounce, get} from 'lodash-es';
 
 
   const uniqIdsMixin = createUniqIdsMixin()
@@ -103,7 +104,7 @@
         allowMultiSelect: false,
         optionsList: [],
         onlyKey: true,
-        debounceGetDataSource: _.debounce((selectedDataSource, selectedEndPoint, dataName, currentValue, key, value,
+        debounceGetDataSource: debounce((selectedDataSource, selectedEndPoint, dataName, currentValue, key, value,
                                            selOptions) => {
           let options = [];
 
@@ -294,7 +295,7 @@
 
           if (this.options.valueTypeReturned === 'single') {
             try {
-            options = Object.values(_.get(this.validationData, dataName))
+            options = Object.values(get(this.validationData, dataName))
                 .map(convertToSelectOptions)
                 .filter(removeInvalidOptions);
               this.optionsList = options;
@@ -309,7 +310,7 @@
               content: (option[value || 'content']).toString(),
             });
             try {
-              options = Object.values(_.get(this.validationData, dataName))
+              options = Object.values(get(this.validationData, dataName))
                 .map(convertObjectToSelectOptions);
               this.optionsList = options;
             } catch(error) {

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -72,8 +72,7 @@
   const uniqIdsMixin = createUniqIdsMixin()
 
   function removeInvalidOptions(option) {
-    return Object.keys(option).includes('value', 'content') &&
-      option.content != null;
+    return Object.keys(option).includes('value') && !!option.content;
   }
 
   export default {

--- a/src/components/mixins/DataFormat.js
+++ b/src/components/mixins/DataFormat.js
@@ -1,5 +1,6 @@
 import Validator from 'validatorjs';
 import moment from 'moment-timezone';
+import { getUserDateFormat, getUserDateTimeFormat } from '../../dateUtils';
 
 // To include another language in the Validator with variable processmaker
 let globalObject = typeof window === 'undefined'
@@ -10,10 +11,15 @@ if (globalObject.ProcessMaker && globalObject.ProcessMaker.user && globalObject.
   Validator.useLang(globalObject.ProcessMaker.user.lang);
 }
 
-Validator.register('date', function(date) {
-  let checkDate = moment(date);
+Validator.register('custom-date', function(date) {
+  let checkDate = moment(date, [getUserDateFormat(), moment.ISO_8601], true);
   return checkDate.isValid();
 }, 'The :attribute must be a valid date.');
+
+Validator.register('custom-datetime', function(date) {
+  let checkDate = moment(date, [getUserDateTimeFormat(), moment.ISO_8601], true);
+  return checkDate.isValid();
+}, 'The :attribute must be a valid date and time.');
 
 export default {
   props: {
@@ -59,8 +65,8 @@ export default {
         'int': 'integer',
         'boolean': 'boolean',
         'string': 'string',
-        'datetime': 'date',
-        'date': 'date',
+        'datetime': 'custom-datetime',
+        'date': 'custom-date',
         'float': 'regex:/^[+-]?\\d+(\\.\\d+)?$/',
         'currency': 'regex:/^[+-]?\\d+(\\.\\d+)?$/',
         'array': 'array',
@@ -95,8 +101,10 @@ export default {
           newValue = parseFloat(newValue);
           break;
         case 'date':
+          newValue = moment(newValue, [getUserDateFormat(), moment.ISO_8601], true).toISOString();
+          break;
         case 'datetime':
-          newValue = moment(newValue).toISOString();
+          newValue = moment(newValue, [getUserDateTimeFormat(), moment.ISO_8601], true).toISOString();
           break;
         case 'int':
           newValue = parseInt(newValue);


### PR DESCRIPTION
added Lodash-es which is tree-shakeable and removed the mentions of lodash from the source code

_in `FormPlainMultiSelect.vue` the `get` wasn't being utilized._ 