### PR TITLE
TICKET-1236 Typo and check fix for filter function

### DIFF
--- a/src/components/FormRadioButtonGroup.vue
+++ b/src/components/FormRadioButtonGroup.vue
@@ -26,8 +26,7 @@ import hasDefaultOptionKey from './mixins/hasDefaultOptionKey';
 const uniqIdsMixin = createUniqIdsMixin();
 
 function removeInvalidOptions(option) {
-  return Object.keys(option).includes('value', 'content') &&
-    option.content !== null;
+  return Object.keys(option).includes('value') && !!option.content;
 }
 
 export default {

--- a/src/components/FormRadioButtonGroup.vue
+++ b/src/components/FormRadioButtonGroup.vue
@@ -26,8 +26,8 @@ import hasDefaultOptionKey from './mixins/hasDefaultOptionKey';
 const uniqIdsMixin = createUniqIdsMixin();
 
 function removeInvalidOptions(option) {
-  return Object.keys(option).includes('value', 'contemnt') &&
-    option.content != null;
+  return Object.keys(option).includes('value', 'content') &&
+    option.content !== null;
 }
 
 export default {

--- a/src/components/FormSelect.vue
+++ b/src/components/FormSelect.vue
@@ -37,8 +37,8 @@ import hasDefaultOptionKey from './mixins/hasDefaultOptionKey';
 const uniqIdsMixin = createUniqIdsMixin()
 
 function removeInvalidOptions(option) {
-  return Object.keys(option).includes('value', 'contemnt') &&
-    option.content != null;
+  return Object.keys(option).includes('value', 'content') &&
+    option.content !== null;
 }
 
 export default {

--- a/src/components/FormSelect.vue
+++ b/src/components/FormSelect.vue
@@ -37,8 +37,7 @@ import hasDefaultOptionKey from './mixins/hasDefaultOptionKey';
 const uniqIdsMixin = createUniqIdsMixin()
 
 function removeInvalidOptions(option) {
-  return Object.keys(option).includes('value', 'content') &&
-    option.content !== null;
+  return Object.keys(option).includes('value') && !!option.content;
 }
 
 export default {

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -71,8 +71,7 @@
   const uniqIdsMixin = createUniqIdsMixin()
 
   function removeInvalidOptions(option) {
-    return Object.keys(option).includes('value', 'content') &&
-      option.content != null;
+    return Object.keys(option).includes('value') && !!option.content;
   }
 
   export default {


### PR DESCRIPTION
Ticket: http://tickets.pm4overflow.com/tickets/1236

Basically there was a typo in the word `content` but noticed that the `.includes` property in Javascript, the types are `searchElement, fromIndex` which `fromIndex` is a type of number, which we were passing a string so invalid.

* Removed the `content` piece
* For those of you who don't know, bang bang or `!!` checks for boolean types (truthy and falsy) in the value provided, meaning it checks in this case if option.content is truthy or falsy.  The function will return if the `Object.keys` are present AND will check if the content inside the option value is present and non falsy.
* `!!option.content` and `option.content !== null` are the same but `!!` is cleaner in my opinion 🤷🏻 