### PR TITLE
Fix render content of selected object value

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -225,8 +225,13 @@
         if (!parsedOption.hasOwnProperty(this.optionsValue)) {
           Object.defineProperty(parsedOption, this.optionsValue, {
             get: function() {
-              const data = {};
-              set(data, suffix, this);
+              // note this = parsedOption
+              let data = {};
+              if (suffix) {
+                set(data, suffix, this);
+              } else {
+                data = this;
+              }
               return Mustache.render(contentProperty, data);
             }
           });


### PR DESCRIPTION
## Issue & Reproduction Steps

When a screen with a SelectList is previously filled is loaded, the value is not displayed to the user
1. Create a Screen with a SelectList Object
2. Assign it to two consecutive Task/Process
3. Run the process
4. Select a value in the first task, submit it
5. Open the second task, the value of the SelectList is not selected/displayed 

## Solution
Fix the mustache render function that returns the value to display.

## How to Test
Follow the Reproduction steps

## Related Tickets and Packages
- Resolves [ticket FOUR-4326](https://processmaker.atlassian.net/browse/FOUR-4326).
- Screen Builder PR https://github.com/ProcessMaker/screen-builder/pull/1114

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
