### PR TITLE
Remove init value, moved to screen-builder

### DIFF
--- a/src/components/FormSelectList/CheckboxView.vue
+++ b/src/components/FormSelectList/CheckboxView.vue
@@ -44,9 +44,6 @@ export default {
       selected:[]
     }
   },
-  mounted() {
-    this.selected = this.value ? this.value : [];
-  },
   watch: {
     value(val) {
       this.selected = val ? val : [];

--- a/src/components/FormSelectList/CheckboxView.vue
+++ b/src/components/FormSelectList/CheckboxView.vue
@@ -44,6 +44,9 @@ export default {
       selected:[]
     }
   },
+  mounted() {
+    this.selected = this.value;
+  },
   watch: {
     value(val) {
       this.selected = val ? val : [];

--- a/src/components/FormSelectList/OptionboxView.vue
+++ b/src/components/FormSelectList/OptionboxView.vue
@@ -44,9 +44,6 @@ export default {
       selected:[]
     }
   },
-  mounted() {
-    this.selected = this.value ? this.value : [];
-  },
   watch: {
     value(val) {
       this.selected = val;

--- a/src/components/FormSelectList/OptionboxView.vue
+++ b/src/components/FormSelectList/OptionboxView.vue
@@ -44,6 +44,9 @@ export default {
       selected:[]
     }
   },
+  mounted() {
+    this.selected = this.value;
+  },
   watch: {
     value(val) {
       this.selected = val;


### PR DESCRIPTION
Fix: https://processmaker.atlassian.net/browse/FOUR-4873

Wrong default value for Radio List (should be null not an empty array)

This PR includes: 
- Remove SelectList (Radio) init value on mount, moved to ScreenBuilder
- Remove SelectList (Checkbox) init value on mount, moved to ScreenBuilder
