### PR TITLE
Validate checkbox list initial value

### DIFF
--- a/src/components/FormSelectList/CheckboxView.vue
+++ b/src/components/FormSelectList/CheckboxView.vue
@@ -10,6 +10,7 @@
           v-model="selected"
           v-bind="$attrs"
           :disabled="isReadOnly"
+          @change="$emit('input', selected)"
       >
       <label :class="labelClass" v-uni-for="getOptionId(option, index)">
         {{getOptionContent(option)}}
@@ -45,15 +46,12 @@ export default {
     }
   },
   mounted() {
-    this.selected = this.value;
+    this.selected = this.value instanceof Array ? this.value : [];
   },
   watch: {
-    value(val) {
-      this.selected = val ? val : [];
+    value(value) {
+      this.selected = value instanceof Array ? value : [];
     },
-    selected() {
-      this.$emit('input', this.selected);
-    }
   },
   computed: {
     divClass() {


### PR DESCRIPTION
When the value of a checkbox list arrives as a `string` it causes the checkbox list malfunction, showing all the boxes checked.

This PR includes:
- Validate value of the control as array
- Change the value only when the user interacts with the control
