### PR TITLE
[4.2] Remove init value, moved to screen-builder

### DIFF
--- a/src/components/FormSelectList/CheckboxView.vue
+++ b/src/components/FormSelectList/CheckboxView.vue
@@ -45,7 +45,7 @@ export default {
     }
   },
   mounted() {
-    this.selected = this.value ? this.value : [];
+    this.selected = this.value;
   },
   watch: {
     value(val) {

--- a/src/components/FormSelectList/CheckboxView.vue
+++ b/src/components/FormSelectList/CheckboxView.vue
@@ -10,6 +10,7 @@
           v-model="selected"
           v-bind="$attrs"
           :disabled="isReadOnly"
+          @change="$emit('input', selected)"
       >
       <label :class="labelClass" v-uni-for="getOptionId(option, index)">
         {{getOptionContent(option)}}
@@ -45,15 +46,12 @@ export default {
     }
   },
   mounted() {
-    this.selected = this.value;
+    this.selected = this.value instanceof Array ? this.value : [];
   },
   watch: {
-    value(val) {
-      this.selected = val ? val : [];
+    value(value) {
+      this.selected = value instanceof Array ? value : [];
     },
-    selected() {
-      this.$emit('input', this.selected);
-    }
   },
   computed: {
     divClass() {

--- a/src/components/FormSelectList/OptionboxView.vue
+++ b/src/components/FormSelectList/OptionboxView.vue
@@ -45,7 +45,7 @@ export default {
     }
   },
   mounted() {
-    this.selected = this.value ? this.value : [];
+    this.selected = this.value;
   },
   watch: {
     value(val) {


### PR DESCRIPTION
Fix: https://processmaker.atlassian.net/browse/FOUR-4873

Wrong default value for Radio List (should be null not an empty array)

This PR includes: 
- Remove SelectList (Radio) init value on mount, moved to ScreenBuilder
- Remove SelectList (Checkbox) init value on mount, moved to ScreenBuilder
