### PR TITLE
Bugfix/FOUR-4955: The first item of a loop with text area rich text, in a record list does not work (For 4.2)

### DIFF
--- a/src/components/FormTextArea.vue
+++ b/src/components/FormTextArea.vue
@@ -95,6 +95,11 @@ export default {
       });
     }, 500);
   },
+  mounted() {
+    window.ProcessMaker.EventBus.$on('modal-shown', () => {
+      this.rebootEditor();
+    });
+  },
   methods: {
     setHeight() {
       if (!this.editorInstance) {


### PR DESCRIPTION
## Issue & Reproduction Steps
When you have a textarea with rich text option enabled inside recordlist, the textarea shows but editing is disabled because the modal is not showing.

Reproduction steps:
- Create a  screen
- Create a  record list 
- Create a  new  page 
- Create  loop
- Inside loop create  text area
- Enable rich text  option in text area
- Click on preview and open the modal (Add)
- The rich text area are showing but you are not able to edit the data
- NOTE: you can import the attached screen

## Solution
- Reboot the textarea on modal shown

## How to Test
- Create a  screen
- Create a  record list 
- Create a  new  page 
- Create  loop
- Inside loop create  text area
- Enable rich text  option in text area
- Click on preview and open the modal (Add)
- The rich text area are showing and you are able to edit the data
- NOTE: you can import the attached screen

[screen text area  4.1.24 (1).json.zip](https://github.com/ProcessMaker/screen-builder/files/7808334/screen.text.area.4.1.24.1.json.zip)

**Working video**

https://user-images.githubusercontent.com/90727999/148114144-15263c53-8d8b-4f56-8aab-ce224586670a.mov


## Related Tickets & Packages
- [FOUR-4955](https://processmaker.atlassian.net/browse/FOUR-4955)
- PR [screen-builder](https://github.com/ProcessMaker/screen-builder/pull/1152)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
