### PR TITLE
Bugfix/FOUR-4950: Field Date picker does not correctly validate the minimum date (For 4.1)

### DIFF
--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -155,7 +155,6 @@ export default {
   },
   methods: {
     parseDate(val) {
-        console.log(9999);
       let date = false;
 
       if (typeof val === 'string' && val !== '') {

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -21,14 +21,12 @@ import ValidationMixin from './mixins/validation';
 import DataFormatMixin from "./mixins/DataFormat";
 import datePicker from 'vue-bootstrap-datetimepicker';
 import moment from 'moment-timezone';
-import { getLang, getTimezone, getUserDateFormat, getUserDateTimeFormat } from '../dateUtils';
+import { getLang, getUserDateFormat, getUserDateTimeFormat } from '../dateUtils';
 import Mustache from 'mustache';
 let Validator = require('validatorjs');
 
 const uniqIdsMixin = createUniqIdsMixin();
 const checkFormats = ['YYYY-MM-DD', moment.ISO_8601];
-
-moment.tz.setDefault(getTimezone());
 
 Validator.register('date_or_mustache', function(value, requirement, attribute) {
   let rendered = null;
@@ -93,7 +91,6 @@ export default {
     config() {
       return {
         format: this.dataFormat === 'datetime' ? getUserDateTimeFormat() : getUserDateFormat(),
-        timeZone: getTimezone(),
         locale: getLang(),
         useCurrent: false,
         showClose: true,
@@ -158,6 +155,7 @@ export default {
   },
   methods: {
     parseDate(val) {
+        console.log(9999);
       let date = false;
 
       if (typeof val === 'string' && val !== '') {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -12,7 +12,6 @@ import FormHtmlViewer from './FormHtmlViewer'
 import FormDelayTimeControl from './FormDelayTimeControl'
 import FormMultiSelect from './FormMultiSelect';
 import FormPlainMultiSelect from './FormPlainMultiSelect';
-import * as dateUtils from '../dateUtils';
 
 // Export our components
 let components = {
@@ -29,7 +28,6 @@ let components = {
     FormDelayTimeControl,
     FormMultiSelect,
     FormPlainMultiSelect,
-    dateUtils,
 }
 
 // Export our named exports

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -12,6 +12,7 @@ import FormHtmlViewer from './FormHtmlViewer'
 import FormDelayTimeControl from './FormDelayTimeControl'
 import FormMultiSelect from './FormMultiSelect';
 import FormPlainMultiSelect from './FormPlainMultiSelect';
+import * as dateUtils from '../dateUtils';
 
 // Export our components
 let components = {
@@ -28,6 +29,7 @@ let components = {
     FormDelayTimeControl,
     FormMultiSelect,
     FormPlainMultiSelect,
+    dateUtils,
 }
 
 // Export our named exports

--- a/src/dateUtils.js
+++ b/src/dateUtils.js
@@ -1,6 +1,5 @@
 /* global ProcessMaker*/
 import moment from 'moment-timezone';
-moment.tz.setDefault(getTimezone())
 
 function getProcessMakerUserValue(key) {
   if (typeof ProcessMaker !== 'undefined' && ProcessMaker.user) {
@@ -30,20 +29,4 @@ export function getUserDateTimeFormat() {
 
 export function isValidDate(date, format = getUserDateFormat()) {
   return moment(date, format).isValid();
-}
-
-export function formatIfDate(string) {
-  let d;
-
-  d = moment(string, 'YYYY-MM-DDTHH:mm:ss.SSSZ', true);
-  if (d.isValid()) {
-    return d.format(getUserDateTimeFormat());
-  }
-
-  d = moment(string, 'YYYY-MM-DDD', true);
-  if (d.isValid()) {
-    return d.format(getUserDateFormat());
-  }
-
-  return string;
 }

--- a/src/dateUtils.js
+++ b/src/dateUtils.js
@@ -1,5 +1,6 @@
 /* global ProcessMaker*/
 import moment from 'moment-timezone';
+moment.tz.setDefault(getTimezone())
 
 function getProcessMakerUserValue(key) {
   if (typeof ProcessMaker !== 'undefined' && ProcessMaker.user) {
@@ -29,4 +30,20 @@ export function getUserDateTimeFormat() {
 
 export function isValidDate(date, format = getUserDateFormat()) {
   return moment(date, format).isValid();
+}
+
+export function formatIfDate(string) {
+  let d;
+
+  d = moment(string, 'YYYY-MM-DDTHH:mm:ss.SSSZ', true);
+  if (d.isValid()) {
+    return d.format(getUserDateTimeFormat());
+  }
+
+  d = moment(string, 'YYYY-MM-DDD', true);
+  if (d.isValid()) {
+    return d.format(getUserDateFormat());
+  }
+
+  return string;
 }


### PR DESCRIPTION
## Issue & Reproduction Steps
Reproduction steps
- Create a screen with 2 datepickers (date1 and date2)
- In date2 in Configuration section, add {{date1}} in Minimum Date field.
- Go to preview and select a date in date1
- Date2 will set the minimum date to the selected date - 1

## Solution
Removed timeZone in config.

## How to Test
- Create a screen with 2 datepickers (date1 and date2)
- In date2 in Configuration section, add {{date1}} in Minimum Date field.
- Go to preview and select a date in date1
- Date2 will set the minimum date to the selected date

**Working video**

https://user-images.githubusercontent.com/90727999/148285428-d2efd318-5ad4-49e7-a1de-4137f84c6202.mov


## Related Tickets & Packages
- [FOUR-4950](https://processmaker.atlassian.net/browse/FOUR-4950)
- [Added e2e tests](https://github.com/ProcessMaker/screen-builder/pull/1153)