### PR TITLE
Bugfix/FOUR-5590: Console error when adding a value for Maximum Date

### DIFF
--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -127,8 +127,6 @@ export default {
         this.validatorErrors = this.validator && this.validator.errors.get(this.name)
           ? this.validator.errors.get(this.name)
           : [];
-          console.log('watch validator');
-          console.log(this.validatorErrors);
 
       },
     },

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -82,12 +82,20 @@ export default {
       date: null,
     }
   },
+  created() {
+    let that = this;
+    Validator.register('after_min_date', function(value, requirement, attribute) {
+      if (that.parseDate(value) < that.parseDate(that.minDate)) {
+        return false;
+      }
+      return true;
+    }, 'Must be after or equal Minimum Date');
+  },
   computed: {
     errors() {
       if (this.error) {
         return [...this.validatorErrors, this.error];
       }
-
       return this.validatorErrors;
     },
     config() {
@@ -97,7 +105,7 @@ export default {
         useCurrent: false,
         showClose: true,
         minDate: this.parseDate(this.minDate),
-        maxDate: this.parseDate(this.maxDate),
+        maxDate: this.checkValidMaxDate(),
         icons: {
           time: 'far fa-clock',
           date: 'far fa-calendar',
@@ -119,6 +127,9 @@ export default {
         this.validatorErrors = this.validator && this.validator.errors.get(this.name)
           ? this.validator.errors.get(this.name)
           : [];
+          console.log('watch validator');
+          console.log(this.validatorErrors);
+
       },
     },
     date() {
@@ -156,6 +167,15 @@ export default {
     },
   },
   methods: {
+    checkValidMaxDate() {
+      if (this.minDate == '') {
+        return this.parseDate(this.maxDate);
+      }
+      if (this.parseDate(this.maxDate) >= this.parseDate(this.minDate)) {
+        return this.parseDate(this.maxDate);
+      }
+      return false;
+    },
     parseDate(val) {
       let date = false;
 


### PR DESCRIPTION
## Issue & Reproduction Steps
- Add a Date Picker control to a screen
- Open the browser dev console
- Open the Configuration right side menu and insert a value for the Maximum Date

## Solution
- Added method to check if max date is valid.
- Added new validation rule to show the error under the field.

## How to Test
- Add a Date Picker control to a screen
- Open the browser dev console
- Open the Configuration right side menu and insert a value for the Maximum Date
- Should not display any errors in the console.
- Try adding a min date and then a max date before the min date, you should see the error under Maximum Date input
- Try adding a min date and then a max date after the min date, you should NOT see the error under Maximum Date input

Run DatePicker.specs e2e tests

**Working video**

https://user-images.githubusercontent.com/90727999/156592050-80d796a2-2f2d-4408-80cc-218ca413545a.mov


## Related Tickets & Packages
- [FOUR-5590](https://processmaker.atlassian.net/browse/FOUR-5590)
- [ScreenBuilder PR](https://github.com/ProcessMaker/screen-builder/pull/1191)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
