### PR TITLE
Bugfix/FOUR-5590_changes: Use arrow function instead that = this

### DIFF
--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -83,9 +83,8 @@ export default {
     }
   },
   created() {
-    let that = this;
-    Validator.register('after_min_date', function(value, requirement, attribute) {
-      if (that.parseDate(value) < that.parseDate(that.minDate)) {
+    Validator.register('after_min_date', (value, requirement, attribute) => {
+      if (this.parseDate(value) < this.parseDate(this.minDate)) {
         return false;
       }
       return true;


### PR DESCRIPTION
Use arrow instead that = this for merged PR [https://github.com/ProcessMaker/vue-form-elements/pull/333](https://github.com/ProcessMaker/vue-form-elements/pull/333)

All e2e tests passed
<img width="1409" alt="Screen Shot 2022-03-22 at 17 28 50" src="https://user-images.githubusercontent.com/90727999/159573305-c030f223-4804-43f7-b4f6-6d640dff2828.png">

