### PR TITLE
Bugfix FOUR-6101 - Error validations are not marked with the color selected in Customize UI (VFE)

### DIFF
--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -9,6 +9,7 @@
       :data-test="dataTest"
       :aria-label="$attrs['aria-label']"
       :tabindex="$attrs['tabindex']"
+      :class="classList"
     />
     <div v-if="errors.length > 0" class="invalid-feedback d-block">
       <div v-for="(error, index) in errors" :key="index">{{error}}</div>
@@ -91,6 +92,11 @@ export default {
     }, 'Must be after or equal Minimum Date');
   },
   computed: {
+    classList() {
+      return {
+        'is-invalid': (this.validator && this.validator.errorCount) || this.error,
+      }
+    },
     errors() {
       if (this.error) {
         return [...this.validatorErrors, this.error];


### PR DESCRIPTION
## Issue & Reproduction Steps
Select List and signature controls, still mark in red, the validation of the required field

1. Go to admin
2. Open Customize UI
3. Select a color different to red in "Danger" option
4. Save the changes
5. Create a Screen
6. Add controls like(line input, textarea, select list, signature)
7. Add Required validation in each control
8. Press preview button

## Solution
- Add `is-invalid` class on Date Picker component.
- Note: The above will add correct border in the `vue-form-renderer` but not in the `vue-form-builder`. I believe we should add a new ticket for that case as it's a different issue, for some reason the validation rules are not being executed in `vue-form-builder` for this component.

## How to Test
- Compile assets, please run `npm link` for screen builder and vue-form-elements.

## Related Tickets & Packages
- [FOUR-6101](https://processmaker.atlassian.net/browse/FOUR-6101)
- [Core Pull Request](https://github.com/ProcessMaker/processmaker/pull/4397)
- [Screen Builder Pull Request](https://github.com/ProcessMaker/screen-builder/pull/1229)