### PR TITLE
FOUR-6696 Debounce not working properly when user types too fast

### DIFF
--- a/src/components/mixins/InputDebounce.js
+++ b/src/components/mixins/InputDebounce.js
@@ -1,7 +1,7 @@
-import debounce from 'lodash/debounce';
+import debounce from "lodash/debounce";
 
 export default {
-  props: ['value'],
+  props: ["value"],
   data() {
     return {
       internalValue: this.value,
@@ -20,10 +20,13 @@ export default {
        * Checking if the event it is a string, if it is a truthy value, and it doesn't have
        * the property target in it
        * */
-      let useDebounce = window.ProcessMaker &&
-        (window.ProcessMaker.debounce === undefined || window.ProcessMaker.debounce === true)
+      const useDebounce =
+        window.ProcessMaker &&
+        (window.ProcessMaker.debounce === undefined ||
+          window.ProcessMaker.debounce === true);
 
-      let value = (!!event && event.target === undefined) ? event : event.target.value;
+      const value =
+        !!event && event.target === undefined ? event : event.target.value;
 
       let valueToEmit = value;
       if (this.convertToData !== undefined) {
@@ -33,17 +36,20 @@ export default {
       if (useDebounce) {
         this.touched = true;
         this.updateValue(valueToEmit);
-      }
-      else {
+      } else {
         this.touched = false;
-        this.$emit('input', valueToEmit);
-        this.$emit('update:value', valueToEmit);
+        this.$emit("input", valueToEmit);
+        this.$emit("update:value", valueToEmit);
       }
     },
-    updateValue: debounce(function (value) {
-      this.touched = false;
-      this.$emit('input', value);
-      this.$emit('update:value', value);
-    }, 500, {'leading': true, 'trailing': false})
+    updateValue: debounce(
+      function (value) {
+        this.touched = false;
+        this.$emit("input", value);
+        this.$emit("update:value", value);
+      },
+      500,
+      { leading: true, trailing: true }
+    )
   }
 };


### PR DESCRIPTION
## Issue & Reproduction Steps
Debounce not working properly when the user was typing too fast on inputs on Screens. Traced it back to the debounce firing on the first keystroke instead of waiting for the user to stop typing and THEN executing the func

## Solution
- Set trailing to be true, to run the function after the time out when multiple items in the queue call

## How to Test
 - Run `npm run build-bundle`
 - `npm link`
 - Link `vue-form-elements` to `screen-builder` and test your changes there in standalone or you can test the changes in core.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6696

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [x] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
