### PR TITLE
FOUR-6760: Fix the multiple refresh with RichText Control

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "validatorjs": "^3.22.1",
     "vue": "^2.6.12",
     "vue-bootstrap-datetimepicker": "^5.0.1",
-    "weekstart": "^1.0.0"
+    "weekstart": "^1.0.0",
+    "vue-uniq-ids": "^1.0.0"
   },
   "devDependencies": {
     "@panter/vue-i18next": "^0.15.0",
@@ -55,8 +56,7 @@
     "mustache": "^3.0.1",
     "prettier": "2.7.1",
     "sass-loader": "^10.2.0",
-    "vue-template-compiler": "^2.6.12",
-    "vue-uniq-ids": "^1.0.0"
+    "vue-template-compiler": "^2.6.12"
   },
   "peerDependencies": {
     "mustache": "^3.0.1"

--- a/src/components/FormHtmlEditor.vue
+++ b/src/components/FormHtmlEditor.vue
@@ -1,74 +1,92 @@
 <template>
-  <div class='form-group'>
+  <div class="form-group">
     <div :class="classList">
       <editor
         v-if="!$attrs.disabled"
-        v-on="$listeners"
-        v-bind="$attrs"
         :value="rendered"
         :init="editorSettings"
+        v-bind="$attrs"
+        v-on="$listeners"
       />
-      <div v-else v-html="rendered"></div>
+      <div v-else>{{ rendered }}</div>
     </div>
-    <div v-if="(validator && validator.errorCount) || error" class="invalid-feedback">
-      <div v-for="(error, index) in validator.errors.get(this.name)" :key="index">{{error}}</div>
-      <div v-if="error">{{error}}</div>
+    <div
+      v-if="(validator && validator.errorCount) || error"
+      class="invalid-feedback"
+    >
+      <div
+        v-for="(error, index) in validator.errors.get(this.name)"
+        :key="index"
+      >
+        {{ error }}
+      </div>
+      <div v-if="error">{{ error }}</div>
     </div>
-    <small v-if='helper' class='form-text text-muted'>{{helper}}</small>
+    <small v-if="helper" class="form-text text-muted">{{ helper }}</small>
   </div>
 </template>
 
-
 <script>
-import { createUniqIdsMixin } from 'vue-uniq-ids'
-import ValidationMixin from './mixins/validation'
-import Mustache from 'mustache';
-import Editor from './Editor'
-import { formatIfDate } from '../dateUtils'
+import { createUniqIdsMixin } from "vue-uniq-ids";
+import Mustache from "mustache";
+import ValidationMixin from "./mixins/validation";
+import Editor from "./Editor";
+import { formatIfDate } from "../dateUtils";
 
 // Create the mixin
-const uniqIdsMixin = createUniqIdsMixin()
+const uniqIdsMixin = createUniqIdsMixin();
 
 export default {
-  inheritAttrs: false,
-  mixins: [uniqIdsMixin, ValidationMixin],
   components: {
     Editor
   },
+  mixins: [uniqIdsMixin, ValidationMixin],
+  inheritAttrs: false,
   props: [
-    'error',
-    'name',
-    'helper',
-    'controlClass',
-    'content',
-    'validationData',
-    'label',
-    'renderVarHtml',
-    // 'value'
+    "error",
+    "name",
+    "helper",
+    "controlClass",
+    "content",
+    "validationData",
+    "label",
+    "renderVarHtml"
   ],
-  computed:{
-    classList(){
-      let classList = {
-        'is-invalid': (this.validator && this.validator.errorCount) || this.error,
+  data() {
+    return {
+      originalEscapeFn: null,
+      customFunctions: {},
+      editorSettings: {
+        inline: true,
+        menubar: false,
+        plugins: ["link", "lists"],
+        toolbar: `undo redo | link | styleselect | bold italic forecolor |
+           alignleft aligncenter alignright alignjustify | bullist numlist outdent indent`,
+        skin: false,
+        relative_urls: false,
+        remove_script_host: false
       }
-      if(this.controlClass){
-        classList[this.controlClass] = true
+    };
+  },
+  computed: {
+    classList() {
+      const classList = {
+        "is-invalid":
+          (this.validator && this.validator.errorCount) || this.error
+      };
+      if (this.controlClass) {
+        classList[this.controlClass] = true;
       }
-      return classList
+      return classList;
     },
     rendered() {
-      if (!this.validationData) {
-        return this.content;
-      }
-
-      this.originalEscapeFn = Mustache.escape;
-      Mustache.escape = this.mustacheEscapeFn;
+      const data = this.makeProxyData();
+      this.overwriteMustacheEscape();
       try {
-        const parent = Object.assign({_parent: this.validationData._parent}, this.validationData);
         if (this.renderVarHtml) {
-          return Mustache.render(this.content, {...this.customFunctions, ...this.validationData, ...parent});
+          return Mustache.render(this.content, data);
         }
-        return Mustache.render(this.content, {...this.customFunctions, ...this.validationData, ...parent});
+        return Mustache.render(this.content, data);
       } catch (error) {
         if (this.renderVarHtml) {
           return this.renderVarName;
@@ -80,32 +98,65 @@ export default {
     }
   },
   methods: {
+    /**
+     * Create a proxy for an empty object. in order to avoid unespected refresh
+     * @return {object} proxy
+     */
+    makeProxyData() {
+      const control = this;
+      const handler = {
+        get: (target, name) => {
+          if (control.customFunctions[name]) {
+            return control.customFunctions[name];
+          }
+          if (name === "_parent") {
+            return (
+              control.validationData._parent || control.validationData._parent
+            );
+          }
+          return control.validationData[name];
+        },
+        has(target, name) {
+          if (control.customFunctions[name]) {
+            return true;
+          }
+          if (name === "_parent") {
+            return true;
+          }
+          return control.validationData[name] !== undefined;
+        }
+      };
+      return new Proxy({}, handler);
+    },
+    /**
+     * Backup and overwrite the original mustache escape property
+     */
+    overwriteMustacheEscape() {
+      this.originalEscapeFn = Mustache.escape;
+      Mustache.escape = this.mustacheEscapeFn;
+    },
+    /**
+     * Register custom functions to be included
+     * @param {string} name
+     * @param {object} implementation
+     */
     registerCustomFunction(name, implementation) {
       this.customFunctions[name] = implementation;
     },
+    /**
+     * Escape the mustache code, added in the tinyMCE editor
+     * @param {string} text
+     * @return {object}
+     */
     mustacheEscapeFn(text) {
-      text = formatIfDate(text);
+      const formatedText = formatIfDate(text);
       if (this.renderVarHtml) {
-        return text;
+        return formatedText;
       }
-      return this.originalEscapeFn(text);
-    }
-  },
-  data() {
-    return {
-      customFunctions: {},
-      editorSettings: {
-        inline: true,
-        menubar: false,
-        plugins: [ 'link', 'lists' ],
-        toolbar: 'undo redo | link | styleselect | bold italic forecolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent',
-        skin: false,
-        relative_urls: false,
-        remove_script_host: false,
-      },
+      return this.originalEscapeFn(formatedText);
     }
   }
-}
+};
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Issue & Reproduction Steps
The control Rich text is refreshed as a result of some action on other controls that are not directly dependent

## Solution
- Add a proxy in the rendered computed property in order to catch all actions.

## How to Test
 - create rich text field
 - add other fields non dependents
 - update the other fields

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-6760

## Code Review Checklist
- [] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [] This solution fixes the bug reported in the original ticket.
- [] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [] This ticket conforms to the PRD associated with this part of ProcessMaker.
