### PR TITLE
Fix SelectList and RichText reactivity problems

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,8 @@
         "validatorjs": "^3.22.1",
         "vue": "^2.6.12",
         "vue-bootstrap-datetimepicker": "^5.0.1",
+        "vue-uniq-ids": "^1.0.0",
+        "vuex": "^3.1.1",
         "weekstart": "^1.0.0"
       },
       "devDependencies": {
@@ -45,8 +47,7 @@
         "mustache": "^3.0.1",
         "prettier": "2.7.1",
         "sass-loader": "^10.2.0",
-        "vue-template-compiler": "^2.6.12",
-        "vue-uniq-ids": "^1.0.0"
+        "vue-template-compiler": "^2.6.12"
       },
       "engines": {
         "node": ">=16 <18",
@@ -15954,8 +15955,7 @@
     "node_modules/qinu": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/qinu/-/qinu-1.2.0.tgz",
-      "integrity": "sha512-tcTCpRzghKo6jfjkQ8tEWwD8qtyOR4cqoVo0/6waSfYT3NM/lTytRCcYNbISFrK1tu7ttowyhY8XpEjleZWybA==",
-      "dev": true
+      "integrity": "sha512-tcTCpRzghKo6jfjkQ8tEWwD8qtyOR4cqoVo0/6waSfYT3NM/lTytRCcYNbISFrK1tu7ttowyhY8XpEjleZWybA=="
     },
     "node_modules/qs": {
       "version": "6.5.3",
@@ -19975,10 +19975,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/vue-uniq-ids/-/vue-uniq-ids-1.0.0.tgz",
       "integrity": "sha1-KUwOzfqj6uddjIUMoABRN9zzS6A=",
-      "dev": true,
       "dependencies": {
         "qinu": "^1.1.2"
       }
+    },
+    "node_modules/vuex": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.1.1.tgz",
+      "integrity": "sha512-ER5moSbLZuNSMBFnEBVGhQ1uCBNJslH9W/Dw2W7GZN23UQA69uapP5GTT9Vm8Trc0PzBSVt6LzF3hGjmv41xcg=="
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -33874,8 +33878,7 @@
     "qinu": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/qinu/-/qinu-1.2.0.tgz",
-      "integrity": "sha512-tcTCpRzghKo6jfjkQ8tEWwD8qtyOR4cqoVo0/6waSfYT3NM/lTytRCcYNbISFrK1tu7ttowyhY8XpEjleZWybA==",
-      "dev": true
+      "integrity": "sha512-tcTCpRzghKo6jfjkQ8tEWwD8qtyOR4cqoVo0/6waSfYT3NM/lTytRCcYNbISFrK1tu7ttowyhY8XpEjleZWybA=="
     },
     "qs": {
       "version": "6.5.3",
@@ -37149,10 +37152,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/vue-uniq-ids/-/vue-uniq-ids-1.0.0.tgz",
       "integrity": "sha1-KUwOzfqj6uddjIUMoABRN9zzS6A=",
-      "dev": true,
       "requires": {
         "qinu": "^1.1.2"
       }
+    },
+    "vuex": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.1.1.tgz",
+      "integrity": "sha512-ER5moSbLZuNSMBFnEBVGhQ1uCBNJslH9W/Dw2W7GZN23UQA69uapP5GTT9Vm8Trc0PzBSVt6LzF3hGjmv41xcg=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "vue": "^2.6.12",
     "vue-bootstrap-datetimepicker": "^5.0.1",
     "vue-uniq-ids": "^1.0.0",
-    "vuex": "^3.1.1",
     "weekstart": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "validatorjs": "^3.22.1",
     "vue": "^2.6.12",
     "vue-bootstrap-datetimepicker": "^5.0.1",
-    "weekstart": "^1.0.0"
+    "weekstart": "^1.0.0",
+    "vue-uniq-ids": "^1.0.0"
   },
   "devDependencies": {
     "@panter/vue-i18next": "^0.15.0",
@@ -55,8 +56,7 @@
     "mustache": "^3.0.1",
     "prettier": "2.7.1",
     "sass-loader": "^10.2.0",
-    "vue-template-compiler": "^2.6.12",
-    "vue-uniq-ids": "^1.0.0"
+    "vue-template-compiler": "^2.6.12"
   },
   "peerDependencies": {
     "mustache": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -32,8 +32,9 @@
     "validatorjs": "^3.22.1",
     "vue": "^2.6.12",
     "vue-bootstrap-datetimepicker": "^5.0.1",
-    "weekstart": "^1.0.0",
-    "vue-uniq-ids": "^1.0.0"
+    "vue-uniq-ids": "^1.0.0",
+    "vuex": "^3.1.1",
+    "weekstart": "^1.0.0"
   },
   "devDependencies": {
     "@panter/vue-i18next": "^0.15.0",

--- a/src/components/FormHtmlEditor.vue
+++ b/src/components/FormHtmlEditor.vue
@@ -80,7 +80,7 @@ export default {
       return classList;
     },
     rendered() {
-      const data = this.makeProxyData();
+      const data = this.makeProxyData(); // Gets the data
       this.overwriteMustacheEscape();
       try {
         if (this.renderVarHtml) {
@@ -99,37 +99,7 @@ export default {
   },
   methods: {
     /**
-     * Create a proxy for an empty object. in order to avoid unespected refresh
-     * @return {object} proxy
-     */
-    makeProxyData() {
-      const control = this;
-      const handler = {
-        get: (target, name) => {
-          if (control.customFunctions[name]) {
-            return control.customFunctions[name];
-          }
-          if (name === "_parent") {
-            return (
-              control.validationData._parent || control.validationData._parent
-            );
-          }
-          return control.validationData[name];
-        },
-        has(target, name) {
-          if (control.customFunctions[name]) {
-            return true;
-          }
-          if (name === "_parent") {
-            return true;
-          }
-          return control.validationData[name] !== undefined;
-        }
-      };
-      return new Proxy({}, handler);
-    },
-    /**
-     * Backup and overwrite the original mustache escape property
+     * Backup and overwrite the original mustache escaped property
      */
     overwriteMustacheEscape() {
       this.originalEscapeFn = Mustache.escape;

--- a/src/components/FormHtmlEditor.vue
+++ b/src/components/FormHtmlEditor.vue
@@ -8,7 +8,7 @@
         v-bind="$attrs"
         v-on="$listeners"
       />
-      <div v-else>{{ rendered }}</div>
+      <div v-else v-html="rendered"></div>
     </div>
     <div
       v-if="(validator && validator.errorCount) || error"

--- a/src/components/FormHtmlEditor.vue
+++ b/src/components/FormHtmlEditor.vue
@@ -1,74 +1,92 @@
 <template>
-  <div class='form-group'>
+  <div class="form-group">
     <div :class="classList">
       <editor
         v-if="!$attrs.disabled"
-        v-on="$listeners"
-        v-bind="$attrs"
         :value="rendered"
         :init="editorSettings"
+        v-bind="$attrs"
+        v-on="$listeners"
       />
-      <div v-else v-html="rendered"></div>
+      <div v-else>{{ rendered }}</div>
     </div>
-    <div v-if="(validator && validator.errorCount) || error" class="invalid-feedback">
-      <div v-for="(error, index) in validator.errors.get(this.name)" :key="index">{{error}}</div>
-      <div v-if="error">{{error}}</div>
+    <div
+      v-if="(validator && validator.errorCount) || error"
+      class="invalid-feedback"
+    >
+      <div
+        v-for="(error, index) in validator.errors.get(this.name)"
+        :key="index"
+      >
+        {{ error }}
+      </div>
+      <div v-if="error">{{ error }}</div>
     </div>
-    <small v-if='helper' class='form-text text-muted'>{{helper}}</small>
+    <small v-if="helper" class="form-text text-muted">{{ helper }}</small>
   </div>
 </template>
 
-
 <script>
-import { createUniqIdsMixin } from 'vue-uniq-ids'
-import ValidationMixin from './mixins/validation'
-import Mustache from 'mustache';
-import Editor from './Editor'
-import { formatIfDate } from '../dateUtils'
+import { createUniqIdsMixin } from "vue-uniq-ids";
+import Mustache from "mustache";
+import ValidationMixin from "./mixins/validation";
+import Editor from "./Editor";
+import { formatIfDate } from "../dateUtils";
 
 // Create the mixin
-const uniqIdsMixin = createUniqIdsMixin()
+const uniqIdsMixin = createUniqIdsMixin();
 
 export default {
-  inheritAttrs: false,
-  mixins: [uniqIdsMixin, ValidationMixin],
   components: {
     Editor
   },
+  mixins: [uniqIdsMixin, ValidationMixin],
+  inheritAttrs: false,
   props: [
-    'error',
-    'name',
-    'helper',
-    'controlClass',
-    'content',
-    'validationData',
-    'label',
-    'renderVarHtml',
-    // 'value'
+    "error",
+    "name",
+    "helper",
+    "controlClass",
+    "content",
+    "validationData",
+    "label",
+    "renderVarHtml"
   ],
-  computed:{
-    classList(){
-      let classList = {
-        'is-invalid': (this.validator && this.validator.errorCount) || this.error,
+  data() {
+    return {
+      originalEscapeFn: null,
+      customFunctions: {},
+      editorSettings: {
+        inline: true,
+        menubar: false,
+        plugins: ["link", "lists"],
+        toolbar: `undo redo | link | styleselect | bold italic forecolor |
+           alignleft aligncenter alignright alignjustify | bullist numlist outdent indent`,
+        skin: false,
+        relative_urls: false,
+        remove_script_host: false
       }
-      if(this.controlClass){
-        classList[this.controlClass] = true
+    };
+  },
+  computed: {
+    classList() {
+      const classList = {
+        "is-invalid":
+          (this.validator && this.validator.errorCount) || this.error
+      };
+      if (this.controlClass) {
+        classList[this.controlClass] = true;
       }
-      return classList
+      return classList;
     },
     rendered() {
-      if (!this.validationData) {
-        return this.content;
-      }
-
-      this.originalEscapeFn = Mustache.escape;
-      Mustache.escape = this.mustacheEscapeFn;
+      const data = this.makeProxyData();
+      this.overwriteMustacheEscape();
       try {
-        const parent = Object.assign({_parent: this.validationData._parent}, this.validationData);
         if (this.renderVarHtml) {
-          return Mustache.render(this.content, {...this.customFunctions, ...this.validationData, ...parent});
+          return Mustache.render(this.content, data);
         }
-        return Mustache.render(this.content, {...this.customFunctions, ...this.validationData, ...parent});
+        return Mustache.render(this.content, data);
       } catch (error) {
         if (this.renderVarHtml) {
           return this.renderVarName;
@@ -80,32 +98,65 @@ export default {
     }
   },
   methods: {
+    /**
+     * Create a proxy for an empty object. in order to avoid unespected refresh
+     * @return {object} proxy
+     */
+    makeProxyData() {
+      const control = this;
+      const handler = {
+        get: (target, name) => {
+          if (control.customFunctions[name]) {
+            return control.customFunctions[name];
+          }
+          if (name === "_parent") {
+            return (
+              control.validationData._parent || control.validationData._parent
+            );
+          }
+          return control.validationData[name];
+        },
+        has(target, name) {
+          if (control.customFunctions[name]) {
+            return true;
+          }
+          if (name === "_parent") {
+            return true;
+          }
+          return control.validationData[name] !== undefined;
+        }
+      };
+      return new Proxy({}, handler);
+    },
+    /**
+     * Backup and overwrite the original mustache escape property
+     */
+    overwriteMustacheEscape() {
+      this.originalEscapeFn = Mustache.escape;
+      Mustache.escape = this.mustacheEscapeFn;
+    },
+    /**
+     * Register custom functions to be included
+     * @param {string} name
+     * @param {object} implementation
+     */
     registerCustomFunction(name, implementation) {
       this.customFunctions[name] = implementation;
     },
+    /**
+     * Escape the mustache code, added in the tinyMCE editor
+     * @param {string} text
+     * @return {object}
+     */
     mustacheEscapeFn(text) {
-      text = formatIfDate(text);
+      const formatedText = formatIfDate(text);
       if (this.renderVarHtml) {
-        return text;
+        return formatedText;
       }
-      return this.originalEscapeFn(text);
-    }
-  },
-  data() {
-    return {
-      customFunctions: {},
-      editorSettings: {
-        inline: true,
-        menubar: false,
-        plugins: [ 'link', 'lists' ],
-        toolbar: 'undo redo | link | styleselect | bold italic forecolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent',
-        skin: false,
-        relative_urls: false,
-        remove_script_host: false,
-      },
+      return this.originalEscapeFn(formatedText);
     }
   }
-}
+};
 </script>
 
 <style scoped>

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -153,7 +153,6 @@
         this.optionsFromDataSource();
       },
        async fillSelectListOptions(strictMode) {
-        console.log("fillSelectListOptions", this.name);
         if (this.options.dataSource && this.options.dataSource === 'provideData') {
           if (this.options && this.options.optionsList && !isEqual(this.selectListOptions, this.options.optionsList)) {
             this.selectListOptions = this.options.optionsList;
@@ -288,7 +287,7 @@
        * the selected value still exists in the new set of options. If it's gone now, then
        * set this control's value to null.
        */
-      updateWatcherDependentFieldValue() {
+      updateWatcherDependentFieldValue(strictMode) {
         let hasKeyInOptions = true;
 
         if (Array.isArray(this.value)) {
@@ -314,7 +313,7 @@
           });
         }
 
-        if (!hasKeyInOptions) {
+        if (!hasKeyInOptions && strictMode) {
           this.$emit('input', null);
         }
       },
@@ -435,7 +434,7 @@
       },
     },
   mounted() {
-    this.fillSelectListOptions(true);
+    this.fillSelectListOptions(false);
     this.registerDynamicWatcher(); 
   }
 }

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -172,11 +172,17 @@ export default {
   mounted() {
     // reset the value to null if the options list does not contain the selected value
     // Special Case String Value:
-    //   Review test tests/e2e/specs/MultiselectWithStringValue.spec.js in ScreenBuilder
+    // Review test tests/e2e/specs/MultiselectWithStringValue.spec.js in ScreenBuilder
     const resetValueIfNotInOptions = typeof this.value !== "string";
     this.fillSelectListOptions(resetValueIfNotInOptions);
   },
   methods: {
+    /**
+     * Load select list options from a data connector
+     * 
+     * @param {object} options 
+     * @returns {boolean}
+     */
     async loadOptionsFromDataConnector(options) {
       const { selectedEndPoint } = options;
       const { selectedDataSource } = options;
@@ -222,9 +228,6 @@ export default {
           { type: "PARAM", key: "pmql", value: pmql }
         ];
       }
-
-      // @todo: Add debounce and/or cache or improve the way to do not re-run the same request
-      // Do not re-run the same request
       const request = { selectedDataSource, params };
       if (isEqual(this.lastRequest, request)) {
         return false;
@@ -410,6 +413,7 @@ export default {
      * If the options list changes due to a dependant field change, we need to check if
      * the selected value still exists in the new set of options. If it's gone now, then
      * set this control's value to null.
+     * @param {boolean} resetValueIfNotInOptions
      */
     updateWatcherDependentFieldValue(resetValueIfNotInOptions) {
       let hasKeyInOptions = true;
@@ -441,6 +445,8 @@ export default {
     },
     /**
      * Returns true if one or more items in list (an array) are in Select List's options
+     * @param {array} list
+     * @returns {boolean}
      */
     areItemsInSelectListOptions(list) {
       if (!Array.isArray(list)) {

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -345,7 +345,6 @@
        */
       registerDynamicWatcher() {
         if (this.options.pmqlQuery) {
-          // const pmqlVariables = this.options.pmqlQuery.match(/{{[^}]+}}/g);
           var pmqlVariables = Mustache.parse(this.options.pmqlQuery)
                        .filter(function(v) { return v[0] === 'name' })
                        .map(function(v) { return v[1]; });
@@ -354,7 +353,6 @@
               const localVariable = this.stripMustache(item);
               this.$watch('validationData.' + localVariable,
               (value) => {
-                console.log("validationData was updated: " + value);
                 this.fillSelectListOptions(true);
                 this.previousValidationData = cloneDeep(this.validationData);
               },

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -175,7 +175,6 @@ export default {
     //   Review test tests/e2e/specs/MultiselectWithStringValue.spec.js in ScreenBuilder
     const resetValueIfNotInOptions = typeof this.value !== "string";
     this.fillSelectListOptions(resetValueIfNotInOptions);
-    this.registerDynamicWatcher();
   },
   methods: {
     async loadOptionsFromDataConnector(options) {
@@ -459,37 +458,6 @@ export default {
       });
 
       return itemsInOptionsList.length > 0;
-    },
-    /**
-     * Register a watcher dinamically
-     * the watcher will be fired when the data[variable] is updated
-     */
-    registerDynamicWatcher() {
-      if (this.options.pmqlQuery) {
-        const pmqlVariables = Mustache.parse(this.options.pmqlQuery)
-          // eslint-disable-next-line func-names
-          .filter(function (v) {
-            return v[0] === "name";
-          })
-          .map(function (v) {
-            return v[1];
-          });
-        if (pmqlVariables.length > 0) {
-          pmqlVariables.forEach((item) => {
-            const localVariable = this.stripMustache(item);
-            this.$watch(
-              `validationData.${localVariable}`,
-              (value) => {
-                this.fillSelectListOptions(true);
-                this.previousValidationData = cloneDeep(this.validationData);
-              },
-              {
-                deep: true
-              }
-            );
-          });
-        }
-      }
     }
   }
 };

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -339,10 +339,16 @@
 
         return itemsInOptionsList.length > 0;
       },
-
+      /**
+       * Register a watcher dinamically
+       * the watcher will be fired when the data[variable] is updated
+       */
       registerDynamicWatcher() {
         if (this.options.pmqlQuery) {
-          const pmqlVariables = this.options.pmqlQuery.match(/{{[^}]+}}/g);
+          // const pmqlVariables = this.options.pmqlQuery.match(/{{[^}]+}}/g);
+          var pmqlVariables = Mustache.parse(this.options.pmqlQuery)
+                       .filter(function(v) { return v[0] === 'name' })
+                       .map(function(v) { return v[1]; });
           if (pmqlVariables.length > 0) {
             pmqlVariables.forEach(item => {
               const localVariable = this.stripMustache(item);

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -184,16 +184,10 @@ export default {
      * @returns {boolean}
      */
     async loadOptionsFromDataConnector(options) {
-      const { selectedEndPoint } = options;
-      const { selectedDataSource } = options;
-      const { dataName } = options;
+      const { selectedEndPoint, selectedDataSource, dataName } = options;
 
       // If no data source has been specified, do not make the api call
-      if (
-        selectedDataSource === null ||
-        typeof selectedDataSource === "undefined" ||
-        selectedDataSource.toString().trim().length === 0
-      ) {
+      if (!!selectedDataSource && selectedDataSource.toString().trim().length === 0) {
         return false;
       }
 
@@ -203,11 +197,7 @@ export default {
       }
 
       // If no endpoint has been specified, do not make the api call
-      if (
-        selectedEndPoint === null ||
-        typeof selectedEndPoint === "undefined" ||
-        selectedEndPoint.toString().trim().length === 0
-      ) {
+      if (!!selectedEndPoint && selectedEndPoint.toString().trim().length === 0) {
         return false;
       }
 
@@ -247,7 +237,7 @@ export default {
         return true;
       } catch (err) {
         /* Ignore error */
-        console.warn(err);
+        console.error(err);
         return false;
       }
     },

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -91,7 +91,7 @@
         previousValidationDataParent: null,
         //apiClient: window.ProcessMaker.apiClient.create(),
         selectListOptions: [],
-        doDebounce: debounce(options => {
+        doDebounce(options) {
           const selectedEndPoint = options.selectedEndPoint;
           const selectedDataSource = options.selectedDataSource;
           const dataName = options.dataName;
@@ -125,6 +125,7 @@
             ];
           }
 
+          // @todo: Add debounce and/or cache or improve the way to do not re-run the same request
           // Do not re-run the same request
           const request = { selectedDataSource, params };
           if (isEqual(this.lastRequest, request)) {
@@ -143,7 +144,7 @@
               .catch(err => {
                 /* Ignore error */
               });
-        }, 700)
+        }
       }
     },
     methods: {

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -51,7 +51,6 @@
 </template>
 
 <script>
-  import { mapState } from "vuex";
   import ValidationMixin from './mixins/validation'
   import {createUniqIdsMixin} from 'vue-uniq-ids'
   import MultiSelectView from "./FormSelectList/MultiSelectView";
@@ -341,7 +340,6 @@
       }
     },
     computed: {
-      ...mapState("globalDataModule", {globalData: "dataChanged"}),
       validatorErrors() {
         return this.validator && this.validator.errors.get(this.name) || [];
       },

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -338,6 +338,27 @@
         });
 
         return itemsInOptionsList.length > 0;
+      },
+
+      registerDynamicWatcher() {
+        if (this.options.pmqlQuery) {
+          const pmqlVariables = this.options.pmqlQuery.match(/{{[^}]+}}/g);
+          if (pmqlVariables.length > 0) {
+            pmqlVariables.forEach(item => {
+              const localVariable = this.stripMustache(item);
+              this.$watch('validationData.' + localVariable,
+              (value) => {
+                console.log("validationData was updated: " + value);
+                this.fillSelectListOptions(true);
+                this.previousValidationData = cloneDeep(this.validationData);
+              },
+              {
+                deep: true
+              }
+              );
+            });
+          }
+        }
       }
     },
     computed: {
@@ -411,6 +432,7 @@
     },
   mounted() {
     this.fillSelectListOptions(true);
+    this.registerDynamicWatcher(); 
   }
 }
 </script>

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -152,7 +152,6 @@
         this.optionsFromDataSource();
       },
       fillSelectListOptions() {
-        console.log("fillSelectListOptions", this.name);
         if (this.options.dataSource && this.options.dataSource === 'provideData') {
           if (this.options && this.options.optionsList && !isEqual(this.selectListOptions, this.options.optionsList)) {
             this.selectListOptions = this.options.optionsList;
@@ -164,7 +163,6 @@
           let requestOptions = []
           try {
             const data = this.makeProxyData();
-            console.log(data, this.options.dataName);
             requestOptions = get(data, this.options.dataName);
           }
           catch(e) {

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -152,7 +152,12 @@
         this.filter = filter;
         this.optionsFromDataSource();
       },
-       async fillSelectListOptions(strictMode) {
+       /**
+        * Transform the options to the format expected by the select list.
+        *
+        * @param {Boolean} resetValueIfNotInOptions
+        */
+       async fillSelectListOptions(resetValueIfNotInOptions) {
         if (this.options.dataSource && this.options.dataSource === 'provideData') {
           if (this.options && this.options.optionsList && !isEqual(this.selectListOptions, this.options.optionsList)) {
             this.selectListOptions = this.options.optionsList;
@@ -177,7 +182,9 @@
         if (this.options.dataSource && this.options.dataSource === 'dataConnector') {
           await this.doDebounce(this.sourceConfig);
         }
-        this.updateWatcherDependentFieldValue(strictMode);
+        this.$nextTick(() => {
+          this.updateWatcherDependentFieldValue(resetValueIfNotInOptions);
+        });
       },
 
 
@@ -287,7 +294,7 @@
        * the selected value still exists in the new set of options. If it's gone now, then
        * set this control's value to null.
        */
-      updateWatcherDependentFieldValue(strictMode) {
+      updateWatcherDependentFieldValue(resetValueIfNotInOptions) {
         let hasKeyInOptions = true;
 
         if (Array.isArray(this.value)) {
@@ -313,7 +320,7 @@
           });
         }
 
-        if (!hasKeyInOptions && strictMode) {
+        if (!hasKeyInOptions && resetValueIfNotInOptions) {
           this.$emit('input', null);
         }
       },
@@ -372,8 +379,7 @@
         return this.toggle ? 'custom-control custom-radio' : 'form-check';
       },
       reactOptions() {
-        console.log("reactOptions", this.name);
-        this.fillSelectListOptions(false);
+        this.fillSelectListOptions(true);
       },
       sourceConfig() {
         return {
@@ -434,7 +440,11 @@
       },
     },
   mounted() {
-    this.fillSelectListOptions(false);
+    // reset the value to null if the options list does not contain the selected value
+    // Special Case String Value:
+    //   Review test tests/e2e/specs/MultiselectWithStringValue.spec.js in ScreenBuilder
+    const resetValueIfNotInOptions = typeof this.value !== "string";
+    this.fillSelectListOptions(resetValueIfNotInOptions);
     this.registerDynamicWatcher(); 
   }
 }

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -152,7 +152,8 @@
         this.filter = filter;
         this.optionsFromDataSource();
       },
-      fillSelectListOptions() {
+       async fillSelectListOptions(strictMode) {
+        console.log("fillSelectListOptions", this.name);
         if (this.options.dataSource && this.options.dataSource === 'provideData') {
           if (this.options && this.options.optionsList && !isEqual(this.selectListOptions, this.options.optionsList)) {
             this.selectListOptions = this.options.optionsList;
@@ -175,8 +176,9 @@
         }
 
         if (this.options.dataSource && this.options.dataSource === 'dataConnector') {
-          this.doDebounce(this.sourceConfig);
+          await this.doDebounce(this.sourceConfig);
         }
+        this.updateWatcherDependentFieldValue(strictMode);
       },
 
 
@@ -347,7 +349,7 @@
       },
       reactOptions() {
         console.log("reactOptions", this.name);
-        this.fillSelectListOptions();
+        this.fillSelectListOptions(false);
       },
       sourceConfig() {
         return {
@@ -408,12 +410,7 @@
       },
     },
   mounted() {
-    this.fillSelectListOptions();
-  },
-  watch: {
-    selectListOptions(newValue, oldValue) {
-      this.updateWatcherDependentFieldValue(newValue, oldValue);
-    }
+    this.fillSelectListOptions(true);
   }
 }
 </script>

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -51,319 +51,434 @@
 </template>
 
 <script>
-  import ValidationMixin from './mixins/validation'
-  import {createUniqIdsMixin} from 'vue-uniq-ids'
-  import MultiSelectView from "./FormSelectList/MultiSelectView";
-  import CheckboxView from "./FormSelectList/CheckboxView";
-  import OptionboxView from "./FormSelectList/OptionboxView";
-  import FormMultiSelect from "./FormMultiSelect";
-  import Mustache from "mustache";
-  import { debounce, isEqual, cloneDeep, get, set } from 'lodash';
+import { createUniqIdsMixin } from "vue-uniq-ids";
+import Mustache from "mustache";
+import { isEqual, cloneDeep, get, set } from "lodash";
+import ValidationMixin from "./mixins/validation";
+import MultiSelectView from "./FormSelectList/MultiSelectView";
+import CheckboxView from "./FormSelectList/CheckboxView";
+import OptionboxView from "./FormSelectList/OptionboxView";
 
-  const uniqIdsMixin = createUniqIdsMixin()
+const uniqIdsMixin = createUniqIdsMixin();
 
-  export default {
-    inheritAttrs: false,
-    components: {
-      OptionboxView,
-      MultiSelectView,
-      CheckboxView,
-      FormMultiSelect,
+export default {
+  components: {
+    OptionboxView,
+    MultiSelectView,
+    CheckboxView
+  },
+  mixins: [uniqIdsMixin, ValidationMixin],
+  inheritAttrs: false,
+  props: [
+    "label",
+    "error",
+    "value",
+    "options",
+    "helper",
+    "name",
+    "controlClass",
+    "validationData",
+    "placeholder",
+    "multiple"
+  ],
+  data() {
+    return {
+      lastRequest: {},
+      previousSourceConfig: null,
+      previousValidationData: null,
+      previousValidationDataParent: null,
+      selectListOptions: []
+    };
+  },
+  computed: {
+    validatorErrors() {
+      return (this.validator && this.validator.errors.get(this.name)) || [];
     },
-    mixins: [uniqIdsMixin, ValidationMixin],
-    props: [
-      'label',
-      'error',
-      'value',
-      'options',
-      'helper',
-      'name',
-      'controlClass',
-      'validationData',
-      'placeholder',
-      'multiple'
-    ],
-    data() {
+    divClass() {
+      return this.toggle ? "custom-control custom-radio" : "form-check";
+    },
+    reactOptions() {
+      this.fillSelectListOptions(true);
+      return undefined;
+    },
+    sourceConfig() {
       return {
-        lastRequest: {},
-        previousSourceConfig: null,
-        previousValidationData: null,
-        previousValidationDataParent: null,
-        //apiClient: window.ProcessMaker.apiClient.create(),
-        selectListOptions: [],
-        async doDebounce(options) {
-          const selectedEndPoint = options.selectedEndPoint;
-          const selectedDataSource = options.selectedDataSource;
-          const dataName = options.dataName;
-
-          // If no data source has been specified, do not make the api call
-          if(selectedDataSource === null || typeof selectedDataSource === 'undefined' || selectedDataSource.toString().trim().length === 0) {
-            return;
-          }
-
-          // Do not run in sandalone mode
-          if (!this.$dataProvider) {
-            return;
-          }
-
-          // If no endpoint has been specified, do not make the api call
-          if(selectedEndPoint === null || typeof selectedEndPoint === 'undefined' || selectedEndPoint.toString().trim().length === 0) {
-            return;
-          }
-
-          let params = {
-            config: {
-              endpoint: selectedEndPoint,
+        dataSource: this.options.dataSource,
+        selectedEndPoint: this.options.selectedEndPoint,
+        selectedDataSource: this.options.selectedDataSource,
+        valueTypeReturned: this.options.valueTypeReturned,
+        dataName: this.options.dataName,
+        value: this.options.value,
+        key: this.options.key
+      };
+    },
+    valueProxy: {
+      get() {
+        if (this.options.renderAs === "dropdown") {
+          let newValue = this.value;
+          if (this.options.valueTypeReturned === "object" && this.value) {
+            if (!Array.isArray(this.value)) {
+              newValue = [this.value];
             }
+            newValue.forEach((item) => {
+              this.addObjectContentProp(item);
+            });
           }
-
-          if (typeof this.options.pmqlQuery !== 'undefined' && this.options.pmqlQuery !== '' && this.options.pmqlQuery !== null) {
-            const data = this.makeProxyData();
-            const pmql = Mustache.render(this.options.pmqlQuery, { data });
-            params.config.outboundConfig = [
-              { type: 'PARAM', key: 'pmql', value: pmql }
-            ];
-          }
-
-          // @todo: Add debounce and/or cache or improve the way to do not re-run the same request
-          // Do not re-run the same request
-          const request = { selectedDataSource, params };
-          if (isEqual(this.lastRequest, request)) {
-            return;
-          }
-          this.lastRequest = cloneDeep(request);
-
-          try {
-            const response = await this.$dataProvider.postDataSource(selectedDataSource, null, params)
-            const list = dataName ? eval('response.data.' + dataName) : response.data;
-
-            const transformedList = this.transformOptions(list);
-            this.$root.$emit('selectListOptionsUpdated', transformedList);
-            this.selectListOptions = transformedList;
-            return true;
-          } catch(err) {
-            /* Ignore error */
-            console.warn(err);
-          }
+          return this.areItemsInSelectListOptions(newValue) ? this.value : [];
         }
+        return this.value;
+      },
+      set(val) {
+        return this.$emit("input", val);
       }
     },
-    methods: {
-      searchChange(filter) {
-        this.filter = filter;
-        this.optionsFromDataSource();
-      },
+    optionsKey() {
+      if (
+        this.options.dataSource &&
+        this.options.dataSource === "provideData"
+      ) {
+        return "value";
+      }
 
-       /**
-        * Transform the options to the format expected by the select list.
-        *
-        * @param {Boolean} resetValueIfNotInOptions
-        */
-       async fillSelectListOptions(resetValueIfNotInOptions) {
-        let wasUpdated = false;
-        if (this.options.dataSource && this.options.dataSource === 'provideData') {
-          if (this.options && this.options.optionsList && !isEqual(this.selectListOptions, this.options.optionsList)) {
-            this.selectListOptions = this.options.optionsList;
-          }
-          this.selectListOptions = this.selectListOptions || [];
-          wasUpdated = true;
+      if (
+        this.options.dataSource &&
+        this.options.dataSource === "dataConnector" &&
+        this.options.valueTypeReturned === "object"
+      ) {
+        return this.optionsValue;
+      }
+
+      const fieldName = this.options.key || "value";
+
+      return this.stripMustache(fieldName);
+    },
+    optionsValue() {
+      if (
+        this.options.dataSource &&
+        this.options.dataSource === "provideData"
+      ) {
+        return "content";
+      }
+      return "__content__";
+    },
+    classList() {
+      return {
+        "has-errors":
+          (this.validator && this.validator.errorCount) || this.error,
+        [this.controlClass]: !!this.controlClass
+      };
+    }
+  },
+  mounted() {
+    // reset the value to null if the options list does not contain the selected value
+    // Special Case String Value:
+    //   Review test tests/e2e/specs/MultiselectWithStringValue.spec.js in ScreenBuilder
+    const resetValueIfNotInOptions = typeof this.value !== "string";
+    this.fillSelectListOptions(resetValueIfNotInOptions);
+    this.registerDynamicWatcher();
+  },
+  methods: {
+    async loadOptionsFromDataConnector(options) {
+      const { selectedEndPoint } = options;
+      const { selectedDataSource } = options;
+      const { dataName } = options;
+
+      // If no data source has been specified, do not make the api call
+      if (
+        selectedDataSource === null ||
+        typeof selectedDataSource === "undefined" ||
+        selectedDataSource.toString().trim().length === 0
+      ) {
+        return false;
+      }
+
+      // Do not run in standalone mode
+      if (!this.$dataProvider) {
+        return false;
+      }
+
+      // If no endpoint has been specified, do not make the api call
+      if (
+        selectedEndPoint === null ||
+        typeof selectedEndPoint === "undefined" ||
+        selectedEndPoint.toString().trim().length === 0
+      ) {
+        return false;
+      }
+
+      const params = {
+        config: {
+          endpoint: selectedEndPoint
+        }
+      };
+
+      if (
+        typeof this.options.pmqlQuery !== "undefined" &&
+        this.options.pmqlQuery !== "" &&
+        this.options.pmqlQuery !== null
+      ) {
+        const data = this.makeProxyData();
+        const pmql = Mustache.render(this.options.pmqlQuery, { data });
+        params.config.outboundConfig = [
+          { type: "PARAM", key: "pmql", value: pmql }
+        ];
+      }
+
+      // @todo: Add debounce and/or cache or improve the way to do not re-run the same request
+      // Do not re-run the same request
+      const request = { selectedDataSource, params };
+      if (isEqual(this.lastRequest, request)) {
+        return false;
+      }
+      this.lastRequest = cloneDeep(request);
+
+      try {
+        const response = await this.$dataProvider.postDataSource(
+          selectedDataSource,
+          null,
+          params
+        );
+        const list = dataName ? get(response.data, dataName) : response.data;
+        const transformedList = this.transformOptions(list);
+        this.$root.$emit("selectListOptionsUpdated", transformedList);
+        this.selectListOptions = transformedList;
+        return true;
+      } catch (err) {
+        /* Ignore error */
+        console.warn(err);
+        return false;
+      }
+    },
+    searchChange(filter) {
+      this.filter = filter;
+      this.optionsFromDataSource();
+    },
+
+    /**
+     * Transform the options to the format expected by the select list.
+     *
+     * @param {Boolean} resetValueIfNotInOptions
+     */
+    async fillSelectListOptions(resetValueIfNotInOptions) {
+      let wasUpdated = false;
+      if (
+        this.options.dataSource &&
+        this.options.dataSource === "provideData"
+      ) {
+        if (
+          this.options &&
+          this.options.optionsList &&
+          !isEqual(this.selectListOptions, this.options.optionsList)
+        ) {
+          this.selectListOptions = this.options.optionsList;
+        }
+        this.selectListOptions = this.selectListOptions || [];
+        wasUpdated = true;
+      }
+
+      if (this.options.dataSource && this.options.dataSource === "dataObject") {
+        let requestOptions = [];
+        try {
+          const data = this.makeProxyData();
+          requestOptions = get(data, this.options.dataName);
+        } catch (e) {
+          requestOptions = [];
         }
 
-        if (this.options.dataSource && this.options.dataSource === 'dataObject') {
-          let requestOptions = []
-          try {
-            const data = this.makeProxyData();
-            requestOptions = get(data, this.options.dataName);
-          } catch (e) {
-            requestOptions = [];
-          }
+        const list = requestOptions || [];
+        this.selectListOptions = this.transformOptions(list);
+        wasUpdated = true;
+      }
 
-          let list = requestOptions ? requestOptions : [];
-          this.selectListOptions = this.transformOptions(list);
-          wasUpdated = true;
-        }
-
-        if (this.options.dataSource && this.options.dataSource === 'dataConnector') {
-          wasUpdated = await this.doDebounce(this.sourceConfig);
-        }
-        if (wasUpdated) {
-          this.$nextTick(() => {
-            this.updateWatcherDependentFieldValue(resetValueIfNotInOptions);
-          });
-        }
-      },
-
-
-      /**
-       * @param {*|*[]} list, array of objects
-       */
-      transformOptions(list) {
-        let suffix = this.attributeParent(this.options.value);
-        let resultList = [];
-
-        list.forEach(item => {
-          // if the content has a mustache expression
-          const escape = Mustache.escape;
-          Mustache.escape = (t) => t; // Do not escape mustache content
-
-          let parsedOption = {};
-          if (this.options.key) {
-            let itemValue = (this.options.key.indexOf('{{') >= 0)
-                          ? Mustache.render(this.options.key, item)
-                          : Mustache.render('{{'+ (this.options.key || 'value') + '}}', item);
-            parsedOption[this.optionsKey] = itemValue;
-          }
-          let itemContent = (this.options.value.indexOf('{{') >= 0)
-                              ? Mustache.render(this.options.value, item)
-                              : Mustache.render('{{'+ (this.options.value || 'content') + '}}', item);
-
-          Mustache.escape = escape; // Reset mustache to original escape function
-
-          parsedOption[this.optionsValue] = itemContent;
-          if (this.options.valueTypeReturned === 'object') {
-            parsedOption = suffix.length > 0 ?  get(item, suffix) : item;
-            if (!parsedOption.hasOwnProperty(this.optionsValue)) {
-              Object.defineProperty(parsedOption, this.optionsValue, {
-                get: function() {
-                  return itemContent;
-                }
-              });
-            }
-          }
-          resultList.push(parsedOption);
+      if (
+        this.options.dataSource &&
+        this.options.dataSource === "dataConnector"
+      ) {
+        wasUpdated = await this.loadOptionsFromDataConnector(this.sourceConfig);
+      }
+      if (wasUpdated) {
+        this.$nextTick(() => {
+          this.updateWatcherDependentFieldValue(resetValueIfNotInOptions);
         });
-        return resultList
-      },
-      addObjectContentProp(parsedOption) {
-        if (!(parsedOption instanceof Object)) {
-          return parsedOption;
+      }
+    },
+
+    /**
+     * @param {*|*[]} list, array of objects
+     */
+    transformOptions(list) {
+      const suffix = this.attributeParent(this.options.value);
+      const resultList = [];
+
+      list.forEach((item) => {
+        // if the content has a mustache expression
+        const { escape } = Mustache;
+        Mustache.escape = (t) => t; // Do not escape mustache content
+
+        let parsedOption = {};
+        if (this.options.key) {
+          const itemValue =
+            this.options.key.indexOf("{{") >= 0
+              ? Mustache.render(this.options.key, item)
+              : Mustache.render(`{{${this.options.key || "value"}}}`, item);
+          parsedOption[this.optionsKey] = itemValue;
         }
-        let suffix = this.attributeParent(this.options.value);
-        let contentProperty = this.options.value;
-        if (contentProperty.indexOf('{{') === -1) {
-          contentProperty = `{{ ${contentProperty} }}`;
-        }
-        if (!parsedOption.hasOwnProperty(this.optionsValue)) {
-          Object.defineProperty(parsedOption, this.optionsValue, {
-            get: function() {
-              // note this = parsedOption
-              let data = {};
-              if (suffix) {
-                set(data, suffix, this);
-              } else {
-                data = this;
+        const itemContent =
+          this.options.value.indexOf("{{") >= 0
+            ? Mustache.render(this.options.value, item)
+            : Mustache.render(`{{${this.options.value || "content"}}}`, item);
+
+        Mustache.escape = escape; // Reset mustache to original escape function
+
+        parsedOption[this.optionsValue] = itemContent;
+        if (this.options.valueTypeReturned === "object") {
+          parsedOption = suffix.length > 0 ? get(item, suffix) : item;
+          if (!parsedOption.hasOwnProperty(this.optionsValue)) {
+            Object.defineProperty(parsedOption, this.optionsValue, {
+              get() {
+                return itemContent;
               }
-              return Mustache.render(contentProperty, data);
-            }
-          });
+            });
+          }
         }
+        resultList.push(parsedOption);
+      });
+      return resultList;
+    },
+    addObjectContentProp(parsedOption) {
+      if (!(parsedOption instanceof Object)) {
         return parsedOption;
-      },
-      stripMustache(str) {
-        const removed =  str.replace(/{{/g,'')
-            .replace(/}}/g,'')
-            .split('.')
-            .pop();
-
-        return removed ? removed : str;
-      },
-      attributeParent(str) {
-        // Check if the value has a mustache expression
-        const isMustache = str.indexOf('{{') >= 0;
-        // If mustache is present, find variables inside mustache
-        if (isMustache) {
-          const mustacheVariables = str.match(/{{[^}]+}}/g);
-          if (mustacheVariables) {
-            let result;
-            mustacheVariables.forEach(variable => {
-              // Get owner variable. Ex. for `data.name.first` owner is `data.name`
-              const stripped = variable.substr(2, variable.length - 4).trim();
-              const splitted = stripped.split('.');
-              splitted.pop();
-              const owner = splitted.join('.');
-              // Select the smallest owner
-              if (!result || result.length > owner.length) {
-                result = owner;
-              }
-            });
-            return result;
+      }
+      const suffix = this.attributeParent(this.options.value);
+      let contentProperty = this.options.value;
+      if (contentProperty.indexOf("{{") === -1) {
+        contentProperty = `{{ ${contentProperty} }}`;
+      }
+      if (!parsedOption.hasOwnProperty(this.optionsValue)) {
+        Object.defineProperty(parsedOption, this.optionsValue, {
+          get() {
+            // note this = parsedOption
+            let data = {};
+            if (suffix) {
+              set(data, suffix, this);
+            } else {
+              data = this;
+            }
+            return Mustache.render(contentProperty, data);
           }
-        } else {
-          const splitted = str.trim().split('.');
-          splitted.pop();
-          const owner = splitted.join('.');
-          return owner;
-        }
-      },
-      /**
-       * If the options list changes due to a dependant field change, we need to check if
-       * the selected value still exists in the new set of options. If it's gone now, then
-       * set this control's value to null.
-       */
-      updateWatcherDependentFieldValue(resetValueIfNotInOptions) {
-        let hasKeyInOptions = true;
-
-        if (Array.isArray(this.value)) {
-          hasKeyInOptions = true;
-          this.value.forEach(item => {
-            let hasItemInOption = this.selectListOptions.find(option => {
-              if (this.options.valueTypeReturned === 'object') {
-                return isEqual(option, item);
-              } else {
-                return get(option, this.optionsKey) === item;
-              }
-            });
-
-            hasKeyInOptions = hasKeyInOptions && hasItemInOption;
-          });
-        } else {
-          hasKeyInOptions = this.selectListOptions.find(option => {
-            if (this.options.valueTypeReturned === 'object') {
-              return isEqual(option, this.value);
-            } else {
-              return get(option, this.optionsKey) === this.value;
-            }
-          });
-        }
-
-        if (!hasKeyInOptions && resetValueIfNotInOptions) {
-          this.$emit('input', null);
-        }
-      },
-      /**
-       * Returns true if one or more items in list (an array) are in Select List's options
-       */
-      areItemsInSelectListOptions(list) {
-        if (!Array.isArray(list)) {
-          return true;
-        }
-
-        const itemsInOptionsList = list.filter(item => {
-          let hasItemInOption = this.selectListOptions.find(option => {
-            if (this.options.valueTypeReturned === 'object') {
-              return isEqual(option, item);
-            } else {
-              return get(option, this.optionsKey) === item;
-            }
-          });
-          return hasItemInOption !== undefined;
         });
+      }
+      return parsedOption;
+    },
+    stripMustache(str) {
+      const removed = str
+        .replace(/{{/g, "")
+        .replace(/}}/g, "")
+        .split(".")
+        .pop();
 
-        return itemsInOptionsList.length > 0;
-      },
-      /**
-       * Register a watcher dinamically
-       * the watcher will be fired when the data[variable] is updated
-       */
-      registerDynamicWatcher() {
-        if (this.options.pmqlQuery) {
-          var pmqlVariables = Mustache.parse(this.options.pmqlQuery)
-                       .filter(function(v) { return v[0] === 'name' })
-                       .map(function(v) { return v[1]; });
-          if (pmqlVariables.length > 0) {
-            pmqlVariables.forEach(item => {
-              const localVariable = this.stripMustache(item);
-              this.$watch('validationData.' + localVariable,
+      return removed || str;
+    },
+    attributeParent(str) {
+      // Check if the value has a mustache expression
+      const isMustache = str.indexOf("{{") >= 0;
+      // If mustache is present, find variables inside mustache
+      if (isMustache) {
+        const mustacheVariables = str.match(/{{[^}]+}}/g);
+        if (mustacheVariables) {
+          let result;
+          mustacheVariables.forEach((variable) => {
+            // Get owner variable. Ex. for `data.name.first` owner is `data.name`
+            const stripped = variable.substr(2, variable.length - 4).trim();
+            const splitted = stripped.split(".");
+            splitted.pop();
+            const owner = splitted.join(".");
+            // Select the smallest owner
+            if (!result || result.length > owner.length) {
+              result = owner;
+            }
+          });
+          return result;
+        }
+      } else {
+        const splitted = str.trim().split(".");
+        splitted.pop();
+        const owner = splitted.join(".");
+        return owner;
+      }
+    },
+    /**
+     * If the options list changes due to a dependant field change, we need to check if
+     * the selected value still exists in the new set of options. If it's gone now, then
+     * set this control's value to null.
+     */
+    updateWatcherDependentFieldValue(resetValueIfNotInOptions) {
+      let hasKeyInOptions = true;
+
+      if (Array.isArray(this.value)) {
+        hasKeyInOptions = true;
+        this.value.forEach((item) => {
+          const hasItemInOption = this.selectListOptions.find((option) => {
+            if (this.options.valueTypeReturned === "object") {
+              return isEqual(option, item);
+            }
+            return get(option, this.optionsKey) === item;
+          });
+
+          hasKeyInOptions = hasKeyInOptions && hasItemInOption;
+        });
+      } else {
+        hasKeyInOptions = this.selectListOptions.find((option) => {
+          if (this.options.valueTypeReturned === "object") {
+            return isEqual(option, this.value);
+          }
+          return get(option, this.optionsKey) === this.value;
+        });
+      }
+
+      if (!hasKeyInOptions && resetValueIfNotInOptions) {
+        this.$emit("input", null);
+      }
+    },
+    /**
+     * Returns true if one or more items in list (an array) are in Select List's options
+     */
+    areItemsInSelectListOptions(list) {
+      if (!Array.isArray(list)) {
+        return true;
+      }
+
+      const itemsInOptionsList = list.filter((item) => {
+        const hasItemInOption = this.selectListOptions.find((option) => {
+          if (this.options.valueTypeReturned === "object") {
+            return isEqual(option, item);
+          }
+          return get(option, this.optionsKey) === item;
+        });
+        return hasItemInOption !== undefined;
+      });
+
+      return itemsInOptionsList.length > 0;
+    },
+    /**
+     * Register a watcher dinamically
+     * the watcher will be fired when the data[variable] is updated
+     */
+    registerDynamicWatcher() {
+      if (this.options.pmqlQuery) {
+        const pmqlVariables = Mustache.parse(this.options.pmqlQuery)
+          // eslint-disable-next-line func-names
+          .filter(function (v) {
+            return v[0] === "name";
+          })
+          .map(function (v) {
+            return v[1];
+          });
+        if (pmqlVariables.length > 0) {
+          pmqlVariables.forEach((item) => {
+            const localVariable = this.stripMustache(item);
+            this.$watch(
+              `validationData.${localVariable}`,
               (value) => {
                 this.fillSelectListOptions(true);
                 this.previousValidationData = cloneDeep(this.validationData);
@@ -371,87 +486,11 @@
               {
                 deep: true
               }
-              );
-            });
-          }
+            );
+          });
         }
       }
-    },
-    computed: {
-      validatorErrors() {
-        return this.validator && this.validator.errors.get(this.name) || [];
-      },
-      divClass() {
-        return this.toggle ? 'custom-control custom-radio' : 'form-check';
-      },
-      reactOptions() {
-        this.fillSelectListOptions(true);
-      },
-      sourceConfig() {
-        return {
-          dataSource: this.options.dataSource,
-          selectedEndPoint: this.options.selectedEndPoint,
-          selectedDataSource: this.options.selectedDataSource,
-          valueTypeReturned: this.options.valueTypeReturned,
-          dataName: this.options.dataName,
-          value: this.options.value,
-          key: this.options.key
-        };
-      },
-      valueProxy: {
-        get() {
-          if (this.options.renderAs === "dropdown") {
-            let newValue = this.value;
-            if (this.options.valueTypeReturned === 'object' && this.value) {
-              if (!Array.isArray(this.value)) {
-                newValue = [this.value];
-              }
-              newValue.forEach(item => {
-                this.addObjectContentProp(item);
-              });
-            }
-            return this.areItemsInSelectListOptions(newValue) ? this.value : [];
-          }
-          return this.value;
-        },
-        set(val) {
-          return this.$emit('input', val);
-        }
-      },
-      optionsKey() {
-        if (this.options.dataSource && this.options.dataSource === 'provideData') {
-          return 'value';
-        }
-
-        if (this.options.dataSource && this.options.dataSource === 'dataConnector' && this.options.valueTypeReturned === 'object') {
-          return this.optionsValue;
-        }
-
-        const fieldName = this.options.key || 'value';
-
-        return this.stripMustache(fieldName);
-      },
-      optionsValue() {
-        if (this.options.dataSource && this.options.dataSource === 'provideData') {
-          return 'content';
-        } else {
-          return '__content__';
-        }
-      },
-      classList() {
-        return {
-          'has-errors': (this.validator && this.validator.errorCount) || this.error,
-          [this.controlClass]: !!this.controlClass
-        }
-      },
-    },
-  mounted() {
-    // reset the value to null if the options list does not contain the selected value
-    // Special Case String Value:
-    //   Review test tests/e2e/specs/MultiselectWithStringValue.spec.js in ScreenBuilder
-    const resetValueIfNotInOptions = typeof this.value !== "string";
-    this.fillSelectListOptions(resetValueIfNotInOptions);
-    this.registerDynamicWatcher(); 
+    }
   }
-}
+};
 </script>

--- a/src/components/mixins/validation.js
+++ b/src/components/mixins/validation.js
@@ -61,19 +61,22 @@ export default {
             const control = this;
             const handler = {
             get: (target, name) => {
+                // customFunctions is used by RichText controls
+                // to add custom Mustache functions
                 if (control.customFunctions && control.customFunctions[name]) {
                     return control.customFunctions[name];
                 }
                 if (name === "_parent") {
                     const screenOwner = control.getScreenOwner();
-                    console.log(screenOwner);
                     return (screenOwner && screenOwner._parent) // Get _parent for the current screen (e.g. Inside Loops, Inside Tabs?, RecordLists...?)
                         || control.validationData._parent; // Get _parent for the Request Data (e.g. Inside a SubProcess)
                 }
                 return control.validationData[name];
             },
             has(target, name) {
-                if (control.customFunctions[name]) {
+                // customFunctions is used by RichText controls
+                // to add custom Mustache functions
+                if (control.customFunctions && control.customFunctions[name]) {
                     return true;
                 }
                 if (name === "_parent") {

--- a/src/components/mixins/validation.js
+++ b/src/components/mixins/validation.js
@@ -101,6 +101,10 @@ export default {
             };
             return new Proxy({}, handler);
         },
+        /**
+         * Gets the screen parent or null if don't have
+         * @returns {object|null}
+         */
         getScreenOwner() {
             let parent = this.$parent;
             while (parent) {

--- a/src/components/mixins/validation.js
+++ b/src/components/mixins/validation.js
@@ -71,6 +71,13 @@ export default {
                     return (screenOwner && screenOwner._parent) // Get _parent for the current screen (e.g. Inside Loops, Inside Tabs?, RecordLists...?)
                         || control.validationData._parent; // Get _parent for the Request Data (e.g. Inside a SubProcess)
                 }
+                // Check if validationData is empty
+                if (
+                    control.validationData === undefined ||
+                    control.validationData === null
+                ) {
+                    return undefined;
+                }
                 return control.validationData[name];
             },
             has(target, name) {
@@ -81,6 +88,13 @@ export default {
                 }
                 if (name === "_parent") {
                     return true;
+                }
+                // Check if validationData is empty
+                if (
+                    control.validationData === undefined ||
+                    control.validationData === null
+                ) {
+                    return false;
                 }
                 return control.validationData[name] !== undefined;
             }


### PR DESCRIPTION
## Issue & Reproduction Steps
There are reactivity problems with multiple components like:
- SelectList
- RichText 

## Solution
Most of the reactivity problems are caused by watching `data`, `validationData`, `_parent` properties and using the option `deep: true`. The code included in this PR modify this problems in components:
- SelectList
- RichText 

## How to Test
- Test with large screens, with or without dependent fields
- Go to preview
- Change some value of any field
- This triggers reactivity of many if not all the elements of the screen

## Related Tickets & Packages
- Required by: https://github.com/ProcessMaker/screen-builder/pull/1258
- https://processmaker.atlassian.net/browse/FOUR-6760

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
