### PR TITLE
FOUR-6749: Write a HttpCache for DataProvider in ScreenBuilder

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -225,19 +225,23 @@ export default {
       this.lastRequest = cloneDeep(request);
 
       try {
-
+        let response = null;
+        window.ProcessMaker.screen= {
+          cacheEnabled:true
+        }
         if (window.ProcessMaker.screen && window.ProcessMaker.screen.cacheEnabled){
-          const response = await this.$dataProvider.getCachedDataSource(   
+          response = await this.$dataProvider.getCachedDataSource(   
             selectedDataSource,
             params
           )
         } else {
-          const response = await this.$dataProvider.postDataSource(
+          response = await this.$dataProvider.postDataSource(
             selectedDataSource,
             null,
             params
           )
         }
+        console.log(response);
         const list = dataName ? get(response.data, dataName) : response.data;
         const transformedList = this.transformOptions(list);
         this.$root.$emit("selectListOptionsUpdated", transformedList);

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -227,10 +227,8 @@ export default {
       try {
         const response = await this.$dataProvider.getDataSource(
           selectedDataSource,
-          null,
           params
         );
-        console.log(response);
         const list = dataName ? get(response.data, dataName) : response.data;
         const transformedList = this.transformOptions(list);
         this.$root.$emit("selectListOptionsUpdated", transformedList);

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -225,11 +225,19 @@ export default {
       this.lastRequest = cloneDeep(request);
 
       try {
-        const response = await this.$dataProvider.postDataSource(
-          selectedDataSource,
-          null,
-          params
-        );
+
+        if (window.ProcessMaker.screen && window.ProcessMaker.screen.cacheEnabled){
+          const response = await this.$dataProvider.getCachedDataSource(   
+            selectedDataSource,
+            params
+          )
+        } else {
+          const response = await this.$dataProvider.postDataSource(
+            selectedDataSource,
+            null,
+            params
+          )
+        }
         const list = dataName ? get(response.data, dataName) : response.data;
         const transformedList = this.transformOptions(list);
         this.$root.$emit("selectListOptionsUpdated", transformedList);

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -225,22 +225,11 @@ export default {
       this.lastRequest = cloneDeep(request);
 
       try {
-        let response = null;
-        window.ProcessMaker.screen= {
-          cacheEnabled:true
-        }
-        if (window.ProcessMaker.screen && window.ProcessMaker.screen.cacheEnabled){
-          response = await this.$dataProvider.getCachedDataSource(   
-            selectedDataSource,
-            params
-          )
-        } else {
-          response = await this.$dataProvider.postDataSource(
-            selectedDataSource,
-            null,
-            params
-          )
-        }
+        const response = await this.$dataProvider.getDataSource(
+          selectedDataSource,
+          null,
+          params
+        );
         console.log(response);
         const list = dataName ? get(response.data, dataName) : response.data;
         const transformedList = this.transformOptions(list);


### PR DESCRIPTION
## Issue & Reproduction Steps
A select list into a loop make services call as the loop **Default Loop Count** says causing repeated calls.

## Solution
We added an axios extension to handle the services and cache 
The code included in this PR modify this problems in components:
- SelectList

## How to Test
- Test with a single screens, with select list inside a loop
- Configure a Data source for the select list 
- Go to preview
- Open the developer tool -> network
- Review if the service is cached 

## Related Tickets & Packages
- Required by: 
- https://processmaker.atlassian.net/browse/FOUR-6749

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
