### PR TITLE
Add missing reactivity for Radio/Checkbox options

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -25,6 +25,7 @@
         :option-value="optionsKey"
         :option-content="optionsValue"
         :options="selectListOptions"
+        :react-options="reactOptions"
         :emit-objects="options.valueTypeReturned === 'object'"
         v-bind="$attrs"
       />
@@ -37,6 +38,7 @@
           :option-value="optionsKey"
           :option-content="optionsValue"
           :options="selectListOptions"
+          :react-options="reactOptions"
           :emit-objects="options.valueTypeReturned === 'object'"
           v-bind="$attrs"
       />


### PR DESCRIPTION
## Issue & Reproduction Steps
Select List of type Radio (and also Checkbox) does not refresh its options after a watcher execution.

Expected behavior: 
After the watcher load the values for the select list options, these options should be updated in the select list control.

Actual behavior: 
Select List of type Radio (and also Checkbox) does not refresh its options after a watcher execution.

## Solution
- Add missing reactivity to refresh the Radio and Checkbox options.

## How to Test
1. Import the screen attached in the ticket
2. Setup the required collection and data source
3. Update the screen watcher to point the prepared data source in step 2
4. Preview the screen
5. Enable the checkbox to trigger the watcher

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6910
- Screen Builder PR: https://github.com/ProcessMaker/screen-builder/pull/1269

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
