### PR TITLE
fix multiselect with string value test

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -98,7 +98,8 @@ export default {
       return this.toggle ? "custom-control custom-radio" : "form-check";
     },
     reactOptions() {
-      this.fillSelectListOptions(true);
+      const resetValueIfNotInOptions = typeof this.value !== "string";
+      this.fillSelectListOptions(resetValueIfNotInOptions);
       return undefined;
     },
     sourceConfig() {
@@ -168,13 +169,6 @@ export default {
         [this.controlClass]: !!this.controlClass
       };
     }
-  },
-  mounted() {
-    // reset the value to null if the options list does not contain the selected value
-    // Special Case String Value:
-    // Review test tests/e2e/specs/MultiselectWithStringValue.spec.js in ScreenBuilder
-    const resetValueIfNotInOptions = typeof this.value !== "string";
-    this.fillSelectListOptions(resetValueIfNotInOptions);
   },
   methods: {
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps
Multi select with string value test fails

Expected behavior: 
the test must work fine

Actual behavior: 
test  MultiselectWithStringValue.spec.js fails in screen-builder project

## Solution
- remove mounted logic and validate if the value is string for first time.

## Related Tickets & Packages


## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
