### PR TITLE
Bugfix/FOUR-7123: Error when the select list has PMQL configured

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "vue": "^2.6.12",
         "vue-bootstrap-datetimepicker": "^5.0.1",
         "vue-uniq-ids": "^1.0.0",
-        "vuex": "^3.1.1",
         "weekstart": "^1.0.0"
       },
       "devDependencies": {
@@ -19979,11 +19978,6 @@
         "qinu": "^1.1.2"
       }
     },
-    "node_modules/vuex": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.1.1.tgz",
-      "integrity": "sha512-ER5moSbLZuNSMBFnEBVGhQ1uCBNJslH9W/Dw2W7GZN23UQA69uapP5GTT9Vm8Trc0PzBSVt6LzF3hGjmv41xcg=="
-    },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -37155,11 +37149,6 @@
       "requires": {
         "qinu": "^1.1.2"
       }
-    },
-    "vuex": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.1.1.tgz",
-      "integrity": "sha512-ER5moSbLZuNSMBFnEBVGhQ1uCBNJslH9W/Dw2W7GZN23UQA69uapP5GTT9Vm8Trc0PzBSVt6LzF3hGjmv41xcg=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/src/components/mixins/ProxyData.js
+++ b/src/components/mixins/ProxyData.js
@@ -24,7 +24,7 @@ export default {
     makeProxyData() {
       const control = this;
       const screen = findScreenOwner(control);
-      return screen.getDataReference(control.customFunctions);
+      return screen ? screen.getDataReference(control.customFunctions) : null;
     }
   }
 };


### PR DESCRIPTION
## Issue & Reproduction Steps
- Create a Screen 
- Config the select list with PMQL
- Press preview button

Expected behavior: 
No error should appear when the select list is configured by PMQL

Actual behavior: 
Error on the top appear when the select list is configured by PMQL. As show in the video  

## Solution
- Validate if screen exists before access getDataReference

**Working video**

https://user-images.githubusercontent.com/90727999/203821684-3c165f30-0477-4a3a-b936-ab80d9ae3405.mov


## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-7123](https://processmaker.atlassian.net/browse/FOUR-7123)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
