### PR TITLE
Bugfix/FOUR-7124: Dependents fields in select is not working 

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -90,7 +90,7 @@ export default {
       previousValidationData: null,
       previousValidationDataParent: null,
       selectListOptions: [],
-      resetValue: false
+      loaded: false
     };
   },
   computed: {
@@ -101,9 +101,19 @@ export default {
       return this.toggle ? "custom-control custom-radio" : "form-check";
     },
     reactOptions() {
-      this.fillSelectListOptions(this.resetValue);
+      const isString = typeof this.value === "string";
+      let resetValueIfNotInOptions = true;
+
+      // If is the first time is loaded and the type of the value is int, 
+      // should not reset the dependent select ..
+      if (!this.loaded && isString) {
+        resetValueIfNotInOptions = false;
+      }
+
       // eslint-disable-next-line vue/no-side-effects-in-computed-properties
-      this.resetValue = true;
+      this.loaded = true;
+      this.fillSelectListOptions(resetValueIfNotInOptions);
+
       return undefined;
     },
     sourceConfig() {

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -104,7 +104,7 @@ export default {
       const isString = typeof this.value === "string";
       let resetValueIfNotInOptions = true;
 
-      // If is the first time is loaded and the type of the value is int, 
+      // If is the first time is loaded and the type of the value is string, 
       // should not reset the dependent select ..
       if (!this.loaded && isString) {
         resetValueIfNotInOptions = false;

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -89,7 +89,8 @@ export default {
       previousSourceConfig: null,
       previousValidationData: null,
       previousValidationDataParent: null,
-      selectListOptions: []
+      selectListOptions: [],
+      resetValue: false
     };
   },
   computed: {
@@ -100,8 +101,8 @@ export default {
       return this.toggle ? "custom-control custom-radio" : "form-check";
     },
     reactOptions() {
-      const resetValueIfNotInOptions = typeof this.value !== "string";
-      this.fillSelectListOptions(resetValueIfNotInOptions);
+      this.fillSelectListOptions(this.resetValue);
+      this.resetValue = true;
       return undefined;
     },
     sourceConfig() {
@@ -248,7 +249,6 @@ export default {
       this.filter = filter;
       this.optionsFromDataSource();
     },
-
     /**
      * Transform the options to the format expected by the select list.
      *

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -102,6 +102,7 @@ export default {
     },
     reactOptions() {
       this.fillSelectListOptions(this.resetValue);
+      // eslint-disable-next-line vue/no-side-effects-in-computed-properties
       this.resetValue = true;
       return undefined;
     },


### PR DESCRIPTION
## Issue & Reproduction Steps
- Import the “tipo, sub_tipo and sub_sub_tipo“ collections
- Import the process/Create process
- The screen in the process has the next configurations:
- Three select list
- Each select list is dependent of the previous 
- Create a requests
- Select “Comida“ in the first select list
- On the second select list should appear (fruta,carne)
- Select fruta
- On the third select list should be listed items according to second list
- Select other option on the first select list “Tecnologia“

Expected behavior: 
The dependent fields should be updated as PM 4.2.35

Actual behavior: 
The dependent fields are not updated according to the selection of the select list

## Solution
- Reset select values always when is not the first time the component is loaded and the type of the value is not string.

**Working videos**

https://user-images.githubusercontent.com/90727999/204620297-32dcc232-85ae-4969-83c5-224ce7048912.mov

https://user-images.githubusercontent.com/90727999/204620227-d7aa2199-499e-4c1c-93bb-54370c98d295.mov


## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-7124](https://processmaker.atlassian.net/browse/FOUR-7124)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

