### PR TITLE
Emit reset instead input

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -447,9 +447,9 @@ export default {
           return get(option, this.optionsKey) === this.value;
         });
       }
-
+      
       if (!hasKeyInOptions && resetValueIfNotInOptions) {
-        this.$emit("input", null);
+        this.$emit("reset", this.name);
       }
     },
     /**


### PR DESCRIPTION
## Issue & Reproduction Steps

- Login
- Create a screen with a select list
- Configure the select list with provide values, for example:
    Content: Option 1, value: 1
    Content: Option 2, value: 2
- Configure in the select list a default value with some none existing value, example: NONE
- Create a process and use the previous screen in a task
- Run a request and open the form task

Expected behavior: 
Screen should not freeze, instead when a default value does not exist in option list, the value should be configured to null

Actual behavior: 
Screen got freeze

## Solution
- Emit a reset event instead input event.

## How to Test
Test the steps above. Ensure screen not getting freeze. Ensure dependent fields are working correctly, please see https://processmaker.atlassian.net/browse/FOUR-7124

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7222
- [Screen builder PR](https://github.com/ProcessMaker/screen-builder/pull/1303)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
