### PR TITLE
FOUR-6854 Replacing the Datepicker!

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,9 +21,8 @@
         "v-calendar": "^0.9.7",
         "validatorjs": "^3.22.1",
         "vue": "^2.6.12",
-        "vue-bootstrap-datetimepicker": "^5.0.1",
+        "vue-date-pick": "^1.5.1",
         "vue-uniq-ids": "^1.0.0",
-        "vuex": "^3.1.1",
         "weekstart": "^1.0.0"
       },
       "devDependencies": {
@@ -14690,34 +14689,6 @@
         "node": ">=0.12"
       }
     },
-    "node_modules/pc-bootstrap4-datetimepicker": {
-      "version": "4.17.51",
-      "resolved": "https://registry.npmjs.org/pc-bootstrap4-datetimepicker/-/pc-bootstrap4-datetimepicker-4.17.51.tgz",
-      "integrity": "sha512-UQDSKS5d1c43btk2vQ4siiv9YIkscZYQfTE513abeTqh5PIOJiyAeNdoCSTsDTZcpWJtWZHWk15yDXypYSFzcQ==",
-      "dependencies": {
-        "bootstrap": "^4.0.0-beta.2",
-        "jquery": "^1.8.3 || ^2.0 || ^3.0",
-        "moment": "^2.10",
-        "moment-timezone": "^0.4.0"
-      },
-      "peerDependencies": {
-        "bootstrap": "^4.0.0-beta.2",
-        "jquery": "^1.8.3 || ^2.0 || ^3.0",
-        "moment": "^2.10",
-        "moment-timezone": "^0.4.0 || ^0.5.0"
-      }
-    },
-    "node_modules/pc-bootstrap4-datetimepicker/node_modules/moment-timezone": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz",
-      "integrity": "sha1-gfWYw61eIs2teWtn7NjYjQ9bqgY=",
-      "dependencies": {
-        "moment": ">= 2.6.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -19726,19 +19697,16 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
       "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
     },
-    "node_modules/vue-bootstrap-datetimepicker": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/vue-bootstrap-datetimepicker/-/vue-bootstrap-datetimepicker-5.0.1.tgz",
-      "integrity": "sha512-jao7sWXHgKzjbOio97u7kEfB/FJMWJ5rhsc4q8iNTOLCULfSJ5m3AZ2qZh62dNcMA4/uuTW6m6tONYIith/2XQ==",
+    "node_modules/vue-date-pick": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/vue-date-pick/-/vue-date-pick-1.5.1.tgz",
+      "integrity": "sha512-7IZDRBgrBUWiF7xMgVAEETq49E//djP7mCbMofLtG91D0IZNbLocT0Z+eueVrJ496lf5WSUE1dF3/ZaOGZW++w==",
       "dependencies": {
-        "pc-bootstrap4-datetimepicker": "^4.17.50"
+        "vue": "^2.6.0"
       },
       "engines": {
-        "node": ">= 6.9.0",
-        "npm": ">= 3.10.0"
-      },
-      "peerDependencies": {
-        "vue": "^2.0.0"
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
       }
     },
     "node_modules/vue-eslint-parser": {
@@ -19978,11 +19946,6 @@
       "dependencies": {
         "qinu": "^1.1.2"
       }
-    },
-    "node_modules/vuex": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.1.1.tgz",
-      "integrity": "sha512-ER5moSbLZuNSMBFnEBVGhQ1uCBNJslH9W/Dw2W7GZN23UQA69uapP5GTT9Vm8Trc0PzBSVt6LzF3hGjmv41xcg=="
     },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
@@ -32807,27 +32770,6 @@
         "sha.js": "^2.4.8"
       }
     },
-    "pc-bootstrap4-datetimepicker": {
-      "version": "4.17.51",
-      "resolved": "https://registry.npmjs.org/pc-bootstrap4-datetimepicker/-/pc-bootstrap4-datetimepicker-4.17.51.tgz",
-      "integrity": "sha512-UQDSKS5d1c43btk2vQ4siiv9YIkscZYQfTE513abeTqh5PIOJiyAeNdoCSTsDTZcpWJtWZHWk15yDXypYSFzcQ==",
-      "requires": {
-        "bootstrap": "^4.0.0-beta.2",
-        "jquery": "^1.8.3 || ^2.0 || ^3.0",
-        "moment": "^2.10",
-        "moment-timezone": "^0.4.0"
-      },
-      "dependencies": {
-        "moment-timezone": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.4.1.tgz",
-          "integrity": "sha1-gfWYw61eIs2teWtn7NjYjQ9bqgY=",
-          "requires": {
-            "moment": ">= 2.6.0"
-          }
-        }
-      }
-    },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -36961,12 +36903,12 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-2.6.14.tgz",
       "integrity": "sha512-x2284lgYvjOMj3Za7kqzRcUSxBboHqtgRE2zlos1qWaOye5yUmHn42LB1250NJBLRwEcdrB0JRwyPTEPhfQjiQ=="
     },
-    "vue-bootstrap-datetimepicker": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/vue-bootstrap-datetimepicker/-/vue-bootstrap-datetimepicker-5.0.1.tgz",
-      "integrity": "sha512-jao7sWXHgKzjbOio97u7kEfB/FJMWJ5rhsc4q8iNTOLCULfSJ5m3AZ2qZh62dNcMA4/uuTW6m6tONYIith/2XQ==",
+    "vue-date-pick": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/vue-date-pick/-/vue-date-pick-1.5.1.tgz",
+      "integrity": "sha512-7IZDRBgrBUWiF7xMgVAEETq49E//djP7mCbMofLtG91D0IZNbLocT0Z+eueVrJ496lf5WSUE1dF3/ZaOGZW++w==",
       "requires": {
-        "pc-bootstrap4-datetimepicker": "^4.17.50"
+        "vue": "^2.6.0"
       }
     },
     "vue-eslint-parser": {
@@ -37155,11 +37097,6 @@
       "requires": {
         "qinu": "^1.1.2"
       }
-    },
-    "vuex": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/vuex/-/vuex-3.1.1.tgz",
-      "integrity": "sha512-ER5moSbLZuNSMBFnEBVGhQ1uCBNJslH9W/Dw2W7GZN23UQA69uapP5GTT9Vm8Trc0PzBSVt6LzF3hGjmv41xcg=="
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@processmaker/vue-form-elements",
-  "version": "0.41.0",
+  "version": "0.41.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@processmaker/vue-form-elements",
-      "version": "0.41.0",
+      "version": "0.41.1",
       "license": "MIT",
       "dependencies": {
         "@tinymce/tinymce-vue": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@tinymce/tinymce-vue": "2.0.0",
         "bootstrap": "^4.5.3",
         "jquery": "^3.5.1",
-        "luxon": "^1.11.3",
         "moment": "^2.29.1",
         "moment-timezone": "^0.5.26",
         "popper.js": "^1.14.4",
@@ -13150,14 +13149,6 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/luxon": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
-      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/make-dir": {
@@ -31515,11 +31506,6 @@
       "requires": {
         "yallist": "^3.0.2"
       }
-    },
-    "luxon": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.28.0.tgz",
-      "integrity": "sha512-TfTiyvZhwBYM/7QdAVDh+7dBTBA29v4ik0Ce9zda3Mnf8on1S5KJI8P2jKFZ8+5C0jhmr0KwJEO/Wdpm0VeWJQ=="
     },
     "make-dir": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@processmaker/vue-form-elements",
-  "version": "0.41.0",
+  "version": "0.41.1",
   "description": "Reusable VueJS Based Form Elements styled with Bootstrap 4",
   "scripts": {
     "serve": "NODE_ENV=standalone vue-cli-service serve",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@tinymce/tinymce-vue": "2.0.0",
     "bootstrap": "^4.5.3",
     "jquery": "^3.5.1",
-    "luxon": "^1.11.3",
     "moment": "^2.29.1",
     "moment-timezone": "^0.5.26",
     "popper.js": "^1.14.4",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "v-calendar": "^0.9.7",
     "validatorjs": "^3.22.1",
     "vue": "^2.6.12",
-    "vue-bootstrap-datetimepicker": "^5.0.1",
+    "vue-date-pick": "^1.5.1",
     "vue-uniq-ids": "^1.0.0",
     "weekstart": "^1.0.0"
   },

--- a/src/DemoApp.vue
+++ b/src/DemoApp.vue
@@ -1,226 +1,249 @@
 <template>
-    <div class="container">
-        <h1>vue-form-elements playground</h1>
-        <form-select-list name="sampleSelectList"
-                     label="Sample Select List"
-                     :options="selectOptions"
-                     v-model="data.sampleSelect"
-                     helper="This is a sample select list field with a validation rule that it must match red"
-                     validation="in:red">
-        </form-select-list>
-        <form-input name="sampleInput"
-                    label="Sample Input with Validation"
-                    helper="This is sample help text for the sample input field. This field is required and has a minimum length of 2 characters."
-                    v-model="data.sampleInput"
-                    :validation="inputValidationRules">
-        </form-input>
-        <form-input name="password.value"
-                    label="Sample Input to support Password masking"
-                    type="password"
-                    helper="This password style implementation has complex validation rules. The field must be 9 characters long with at least one alphabetic, lower and upper case, numeric and symbol"
-                    v-model="data.password.value"
-                    :validation="passwordValidationRules">
-        </form-input>
-        <form-input name="password.confirm"
-                    label="Sample Input with validation rule to match another property"
-                    type="password"
-                    helper="This password style has validation rules to match another field"
-                    v-model="data.password.confirm"
-                    :validationData="data"
-                    :validation="confirmPasswordValidationRules">
-        </form-input>
-        <form-input name="sampleError"
-                    label="Sample Field With External Forced Error"
-                    helper="This field will show an error by using the error prop. This example field is controlling the data that will be passed in to the error prop"
-                    :error="data.sampleError"
-                    v-model="data.sampleError">
-        </form-input>
-        <form-input name="sampleCustomValidationError"
-                    label="Sample Custom Validation Message"
-                    helper="This field has a required field that has a custom validation error message by using the validationMessages property."
-                    v-model="data.sampleCustomValidationError"
-                    validation="required"
-                    :validationMessages="customValidationMessages">
-        </form-input>
-        <form-text-area name="sampleText"
-                        label="Sample Text Area"
-                        rows="4"
-                        helper="This text area has a maximum character limit of 20 validation rule."
-                        error="This error is shown by default"
-                        validation="max:20"
-                        :richtext="richtext"
-                        v-model="data.sampleText">
-        </form-text-area>
-        Current Character Count: {{data.sampleText.length}}
-        <form-checkbox name="useRichtext"
-                       label="Use richtext editor for above textarea"
-                       v-model="richtext"
-                       toggle="true"
-                       helper="">
-        </form-checkbox>
+  <div class="container">
+    <h1>vue-form-elements playground</h1>
+    <form-select-list
+      v-model="data.sampleSelect"
+      name="sampleSelectList"
+      label="Sample Select List"
+      :options="selectOptions"
+      helper="This is a sample select list field with a validation rule that it must match red"
+      validation="in:red"
+    >
+    </form-select-list>
+    <form-input
+      v-model="data.sampleInput"
+      name="sampleInput"
+      label="Sample Input with Validation"
+      helper="This is sample help text for the sample input field. This field is required and has a minimum length of 2 characters."
+      :validation="inputValidationRules"
+    >
+    </form-input>
+    <form-input
+      v-model="data.password.value"
+      name="password.value"
+      label="Sample Input to support Password masking"
+      type="password"
+      helper="This password style implementation has complex validation rules. The field must be 9 characters long with at least one alphabetic, lower and upper case, numeric and symbol"
+      :validation="passwordValidationRules"
+    >
+    </form-input>
+    <form-input
+      v-model="data.password.confirm"
+      name="password.confirm"
+      label="Sample Input with validation rule to match another property"
+      type="password"
+      helper="This password style has validation rules to match another field"
+      :validation-data="data"
+      :validation="confirmPasswordValidationRules"
+    >
+    </form-input>
+    <form-input
+      v-model="data.sampleError"
+      name="sampleError"
+      label="Sample Field With External Forced Error"
+      helper="This field will show an error by using the error prop. This example field is controlling the data that will be passed in to the error prop"
+      :error="data.sampleError"
+    >
+    </form-input>
+    <form-input
+      v-model="data.sampleCustomValidationError"
+      name="sampleCustomValidationError"
+      label="Sample Custom Validation Message"
+      helper="This field has a required field that has a custom validation error message by using the validationMessages property."
+      validation="required"
+      :validation-messages="customValidationMessages"
+    >
+    </form-input>
+    <form-text-area
+      v-model="data.sampleText"
+      name="sampleText"
+      label="Sample Text Area"
+      rows="4"
+      helper="This text area has a maximum character limit of 20 validation rule."
+      error="This error is shown by default"
+      validation="max:20"
+      :richtext="richtext"
+    >
+    </form-text-area>
+    Current Character Count: {{ data.sampleText.length }}
+    <form-checkbox
+      v-model="richtext"
+      name="useRichtext"
+      label="Use richtext editor for above textarea"
+      toggle="true"
+      helper=""
+    >
+    </form-checkbox>
 
+    <form-select
+      v-model="data.sampleSelect"
+      name="sampleSelect"
+      label="Sample Select"
+      :options="selectOptions"
+      helper="This is a sample select field with a validation rule that it must match red"
+      validation="in:red"
+    >
+    </form-select>
+    <form-radio-button-group
+      name="sampleRadioButtonGroup"
+      label="Sample Radio Button Group"
+      :options="radioButtonOptions"
+      helper="This shows rendering a radio button group with a required validation rule"
+      validation="required"
+    >
+    </form-radio-button-group>
+    <form-checkbox
+      v-model="data.sampleCheckbox"
+      name="sampleCheckbox"
+      label="Sample Checkbox"
+      helper="This checkbox represents a boolean in the data model."
+    >
+    </form-checkbox>
+    Current Value: {{ data.sampleCheckbox }}
 
+    <form-checkbox
+      v-model="data.sampleCustomCheckbox"
+      name="sampleCustomCheckbox"
+      label="Sample Custom Checkbox"
+      toggle="true"
+      helper="This checkbox represents a boolean in the data model. Need parameter 'toggle=true' for enable custom switches"
+    >
+    </form-checkbox>
 
-        <form-select name="sampleSelect"
-                     label="Sample Select"
-                     :options="selectOptions"
-                     v-model="data.sampleSelect"
-                     helper="This is a sample select field with a validation rule that it must match red"
-                     validation="in:red">
-        </form-select>
-        <form-radio-button-group name="sampleRadioButtonGroup"
-                                 label="Sample Radio Button Group"
-                                 :options="radioButtonOptions"
-                                 helper="This shows rendering a radio button group with a required validation rule"
-                                 validation="required">
-        </form-radio-button-group>
-        <form-checkbox name="sampleCheckbox"
-                       label="Sample Checkbox"
-                       v-model="data.sampleCheckbox"
-                       helper="This checkbox represents a boolean in the data model.">
-        </form-checkbox>
-        Current Value: {{data.sampleCheckbox}}
-
-        <form-checkbox name="sampleCustomCheckbox"
-                       label="Sample Custom Checkbox"
-                       v-model="data.sampleCustomCheckbox"
-                       toggle="true"
-                       helper="This checkbox represents a boolean in the data model. Need parameter 'toggle=true' for enable custom switches">
-        </form-checkbox>
-
-        Current Value: {{data.sampleCustomCheckbox}}
-        <form-radio-button-group name="sampleCustomRadioButtonGroup"
-                                 toggle="true"
-                                 label="Sample Custom Radio Button Group"
-                                 :options="radioButtonOptions"
-                                 helper="This shows rendering a radio button group with a required validation rule. Need parameter 'toggle=true' for enable custom radio"
-                                 validation="required">
-        </form-radio-button-group>
-        <form-date-picker
-                label="Sample calendar"
-                placeholder="Placeholder Sample Calendar"
-                helper="Helper Sample Calendar, Theming is supported by overwriting CSS classes."
-                data-format="datetime"
-                v-model="data.sampleDatePicker"
-        />
-        <form-html-editor
-            label="Sample Html Editor"
-            :content="data.sampleHtmlText"
-            @input="data.sampleHtmlText = $event"
-        />
-        <form-text-area
-          label="HTML Output"
-          v-model="data.sampleHtmlText"
-        ></form-text-area>
-        <form-delay-time-control
-            name="sampleDelayTimeControl"
-            v-model="data.sampleDelayTimeControl"
-            label="Sample delay time control"
-            helper="Example 7 minutes (PT7M)"
-            validation="required"
-        />
-    </div>
+    Current Value: {{ data.sampleCustomCheckbox }}
+    <form-radio-button-group
+      name="sampleCustomRadioButtonGroup"
+      toggle="true"
+      label="Sample Custom Radio Button Group"
+      :options="radioButtonOptions"
+      helper="This shows rendering a radio button group with a required validation rule. Need parameter 'toggle=true' for enable custom radio"
+      validation="required"
+    >
+    </form-radio-button-group>
+    <form-date-picker
+      v-model="data.sampleDatePicker"
+      label="Sample calendar"
+      placeholder="Placeholder Sample Calendar"
+      helper="Helper Sample Calendar, Theming is supported by overwriting CSS classes."
+      data-format="datetime"
+    />
+    <form-html-editor
+      label="Sample Html Editor"
+      :content="data.sampleHtmlText"
+      @input="data.sampleHtmlText = $event"
+    />
+    <form-text-area
+      v-model="data.sampleHtmlText"
+      label="HTML Output"
+    ></form-text-area>
+    <form-delay-time-control
+      v-model="data.sampleDelayTimeControl"
+      name="sampleDelayTimeControl"
+      label="Sample delay time control"
+      helper="Example 7 minutes (PT7M)"
+      validation="required"
+    />
+  </div>
 </template>
 
-
 <script>
-  // We're bringing in our Vue plugin
-  import Vue from 'vue'
-  import VueFormElements from './components/index';
-  import FormDatePicker from './components/FormDatePicker';
-  import { DateTime } from 'luxon';
+// We're bringing in our Vue plugin
+import Vue from "vue";
+import VueFormElements from "./components/index";
+import FormDatePicker from "./components/FormDatePicker";
 
-  // Register our plugin
-  Vue.use(VueFormElements)
+// Register our plugin
+Vue.use(VueFormElements);
 
-  export default {
-    components: {FormDatePicker},
-    data() {
-      return {
-        // The data model to bind our elements to
-        data: {
-          sampleInput: '',
-          sampleText: '',
-          sampleHtmlText: '<h3>Edit this text inline</h3> <ul> <li>Add some <a href="https://github.com/ProcessMaker/vue-form-elements/branches">links</a></li> <li><span style="color: #8e44ad;">Color</span> some text</li> </ul>',
-          // Shows off ability to nest and refer to items deep in data model
-          password: {
-            value: '',
-            confirm: ''
-          },
-          sampleCheckbox: false,
-          sampleCustomCheckbox: false,
-          sampleRadioButtonGroup: '',
-          sampleSelect: '',
-          sampleCustomValidationError: '',
-          sampleDatePicker: DateTime.local().toISO(),
-          sampleDelayTimeControl: '',
+export default {
+  components: { FormDatePicker },
+  data() {
+    return {
+      // The data model to bind our elements to
+      data: {
+        sampleInput: "",
+        sampleText: "",
+        sampleHtmlText:
+          "<h3>Edit this text inline</h3> <ul> <li>Add some <a href=\"https://github.com/ProcessMaker/vue-form-elements/branches\">links</a></li> <li><span style=\"color: #8e44ad;\">Color</span> some text</li> </ul>",
+        // Shows off ability to nest and refer to items deep in data model
+        password: {
+          value: "",
+          confirm: ""
         },
-        richtext: false,
-        inputValidationRules: 'required|min:2',
-        textValidationRules: 'max:255',
-        passwordValidationRules: 'required|regex:/(?=.{9,})(?=.*?[^\\w\\s])(?=.*?[0-9])(?=.*?[A-Z]).*?[a-z].*/',
-        confirmPasswordValidationRules: 'required|same:password.value',
-        selectOptions: {
-          defaultOptionKey: 'red',
-          key: 'value',
-          value: 'content',
-          jsonData: JSON.stringify([
-            {
-              content: 'Green',
-              value: 'green'
-            },
-            {
-              content: 'Red',
-              value: 'red'
-            },
-            {
-              content: 'Blue',
-              value: 'blue'
-            },
-            {
-              content: 'Yellow',
-              value: 'yellow'
-            },
-            {
-              content: 'White',
-              value: 'white'
-            },
-            {
-              content: 'Black',
-              value: 'black'
-            },
-          ])
+        sampleCheckbox: false,
+        sampleCustomCheckbox: false,
+        sampleRadioButtonGroup: "",
+        sampleSelect: "",
+        sampleCustomValidationError: "",
+        sampleDatePicker: new Date().toISOString(),
+        sampleDelayTimeControl: ""
+      },
+      richtext: false,
+      inputValidationRules: "required|min:2",
+      textValidationRules: "max:255",
+      passwordValidationRules:
+        "required|regex:/(?=.{9,})(?=.*?[^\\w\\s])(?=.*?[0-9])(?=.*?[A-Z]).*?[a-z].*/",
+      confirmPasswordValidationRules: "required|same:password.value",
+      selectOptions: {
+        defaultOptionKey: "red",
+        key: "value",
+        value: "content",
+        jsonData: JSON.stringify([
+          {
+            content: "Green",
+            value: "green"
+          },
+          {
+            content: "Red",
+            value: "red"
+          },
+          {
+            content: "Blue",
+            value: "blue"
+          },
+          {
+            content: "Yellow",
+            value: "yellow"
+          },
+          {
+            content: "White",
+            value: "white"
+          },
+          {
+            content: "Black",
+            value: "black"
+          }
+        ])
+      },
+      radioButtonOptions: [
+        {
+          content: "Small",
+          value: "small"
         },
-        radioButtonOptions: [
-          {
-            content: 'Small',
-            value: 'small'
-          },
-          {
-            content: 'Medium',
-            value: 'medium'
-          },
-          {
-            content: 'Large',
-            value: 'large'
-          },
-          {
-            content: 'X-Large',
-            value: 'xlarge'
-          },
-        ],
-        customValidationMessages: {
-          required: 'This field is totally required and you should, like, put it in.'
+        {
+          content: "Medium",
+          value: "medium"
+        },
+        {
+          content: "Large",
+          value: "large"
+        },
+        {
+          content: "X-Large",
+          value: "xlarge"
         }
+      ],
+      customValidationMessages: {
+        required:
+          "This field is totally required and you should, like, put it in."
       }
-    }
-
+    };
   }
+};
 </script>
 
 <style lang="scss" scoped>
-    .container {
-        margin-bottom: 32px;
-    }
-
+.container {
+  margin-bottom: 32px;
+}
 </style>

--- a/src/components/DatePicker.vue
+++ b/src/components/DatePicker.vue
@@ -1,0 +1,29 @@
+<script>
+import DatePick from "vue-date-pick";
+
+/*
+Internal fork of the DatePick library by extending it and fixing the {close,remove} events to target the b-modal
+(Bootstrap-Vue) modals to not "focus-in" automatically on the input text.
+ */
+export default {
+  extends: DatePick,
+  methods: {
+    addCloseEvents() {
+      if (!this.closeEventListener) {
+        this.closeEventListener = (e) => this.inspectCloseEvent(e);
+        ["click", "keyup"].forEach((eventName) =>
+          document.addEventListener(eventName, this.closeEventListener)
+        );
+      }
+    },
+    removeCloseEvents() {
+      if (!this.closeEventListener) {
+        this.closeEventListener = (e) => this.inspectCloseEvent(e);
+        ["click", "keyup"].forEach((eventName) =>
+          document.addEventListener(eventName, this.closeEventListener)
+        );
+      }
+    }
+  }
+};
+</script>

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -21,9 +21,9 @@
 
 <script>
 import { createUniqIdsMixin } from "vue-uniq-ids";
-import DatePick from "vue-date-pick";
 import moment from "moment-timezone";
 import Mustache from "mustache";
+import DatePicker from "./DatePicker.vue";
 import ValidationMixin from "./mixins/validation";
 import DataFormatMixin from "./mixins/DataFormat";
 import { getUserDateFormat, getUserDateTimeFormat } from "../dateUtils";
@@ -62,7 +62,7 @@ Validator.register(
 
 export default {
   components: {
-    DatePick
+    "date-pick": DatePicker
   },
   mixins: [uniqIdsMixin, ValidationMixin, DataFormatMixin],
   props: {
@@ -90,7 +90,10 @@ export default {
   data() {
     return {
       validatorErrors: [],
-      date: "",
+      date:
+        !!this.value && this.value.length > 0
+          ? this.parsingInputDate(this.value)
+          : "",
       inputAttributes: {
         class: `${this.inputClass}`,
         placeholder: this.placeholder,

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -5,10 +5,7 @@
       v-model="date"
       v-bind="config"
       :format="format"
-      :placeholder="placeholder"
       :data-test="dataTest"
-      :aria-label="ariaLabel"
-      :tabindex="tabIndex"
       :class="classList"
       :input-attributes="inputAttributes"
     />
@@ -93,10 +90,12 @@ export default {
     return {
       validatorErrors: [],
       date: "",
-      datepicker: this.dataFormat === "datetime",
-      format: this.datepicker ? getUserDateTimeFormat() : getUserDateFormat(),
       inputAttributes: {
-        class: `${this.inputClass}`
+        class: `${this.inputClass}`,
+        placeholder: this.placeholder,
+        name: this.name,
+        ariaLabel: this.ariaLabel,
+        tabIndex: this.tabIndex
       }
     };
   },
@@ -107,8 +106,15 @@ export default {
         pickTime: this.datepicker,
         parseDate: this.parseDate,
         formatDate: this.formatDate,
-        editable: !this.disabled
+        editable: !this.disabled,
+        use12HourClock: this.datepicker
       };
+    },
+    datepicker() {
+      return this.dataFormat === "datetime";
+    },
+    format() {
+      return this.datepicker ? getUserDateTimeFormat() : getUserDateFormat();
     },
     classList() {
       return {
@@ -191,7 +197,8 @@ export default {
       //
       // return date;
       console.log("parseDate", val);
-      const date = moment(val, this.format);
+      const date = moment(val, this.format, true);
+      if (!date.isValid()) return false;
       console.log("date", date.toString());
       return date.toDate();
     },

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -109,7 +109,7 @@ export default {
         formatDate: this.formatDate,
         editable: !this.disabled,
         use12HourClock: this.datepicker,
-        isDateDisabled: this.isFutureDate
+        isDateDisabled: this.checkMinMaxDate
       };
     },
     datepicker() {
@@ -174,15 +174,6 @@ export default {
     );
   },
   methods: {
-    checkValidMaxDate() {
-      if (this.minDate === "") {
-        return this.parseDate(this.maxDate);
-      }
-      if (this.parseDate(this.maxDate) >= this.parseDate(this.minDate)) {
-        return this.parseDate(this.maxDate);
-      }
-      return false;
-    },
     parseDate(val) {
       // let date;
       // console.log("parseDate", val);
@@ -213,21 +204,7 @@ export default {
       console.log("formatDate", date);
       return date;
     },
-    startPeriod() {
-      return this.parseMinDate(this.minDate);
-    },
-    // For some reason, is being executed 35 times on date change
-    parseMinDate(value) {
-      if (value === "")
-        return {
-          month: new Date().getMonth(),
-          year: new Date().getFullYear()
-        };
-      const month = new Date(value).getMonth();
-      const year = new Date(value).getFullYear();
-      return { month, year };
-    },
-    isFutureDate(date) {
+    checkMinMaxDate(date) {
       const minDate = !!this.minDate ? new Date(this.minDate) : "";
       const maxDate = !!this.maxDate ? new Date(this.maxDate) : "";
       if (minDate.length === 0 && maxDate.length === 0) return;

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -14,7 +14,9 @@
     <div v-if="errors.length > 0" class="invalid-feedback d-block">
       <div v-for="(err, index) in errors" :key="index">{{ err }}</div>
     </div>
-    <small v-if="helper" class="form-text text-muted">{{ helper }}</small>
+    <small v-if="helper" v-once class="form-text text-muted">{{
+      helper
+    }}</small>
   </div>
 </template>
 

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -101,6 +101,9 @@ export default {
     };
   },
   computed: {
+    startPeriod() {
+      return this.parseMinDate(this.minDate);
+    },
     config() {
       return {
         format: this.format,
@@ -108,7 +111,9 @@ export default {
         parseDate: this.parseDate,
         formatDate: this.formatDate,
         editable: !this.disabled,
-        use12HourClock: this.datepicker
+        use12HourClock: this.datepicker,
+        // startPeriod: this.startPeriod,
+        isDateDisabled: this.checkValidMaxDate
       };
     },
     datepicker() {
@@ -134,6 +139,7 @@ export default {
     validator: {
       deep: true,
       handler() {
+        console.log("validator errors", this.validator);
         this.validatorErrors =
           this.validator && this.validator.errors.get(this.name)
             ? this.validator.errors.get(this.name)
@@ -181,32 +187,46 @@ export default {
       return false;
     },
     parseDate(val) {
-      // let date = false;
+      // let date;
+      // console.log("parseDate", val);
       //
       // if (typeof val === "string" && val !== "") {
+      //   console.log("typeof if");
       //   try {
       //     date = Mustache.render(val, this.validationData);
       //   } catch (error) {
       //     date = val;
       //   }
       //
-      //   date = moment(date, checkFormats, true);
+      //   date = moment(date, this.format, true);
+      //   console.log("date moment", date);
       //   if (!date.isValid()) {
-      //     date = false;
+      //     date = this.value;
+      //     return date;
       //   }
       // }
       //
-      // return date;
-      console.log("parseDate", val);
+      // return date.toDate();
       const date = moment(val, this.format, true);
       if (!date.isValid()) return false;
-      console.log("date", date.toString());
       return date.toDate();
     },
     formatDate(val) {
       const date = moment(val).format(this.format);
       console.log("formatDate", date);
       return date;
+    },
+    parseMinDate(value) {
+      console.log("value parseMinDate", value);
+      const month = new Date(value).getMonth();
+      const year = new Date(value).getFullYear();
+      console.log({ month, year });
+      return { month, year };
+    },
+    isFutureDate(date) {
+      console.log("date isFutureDate", date);
+      const currentDate = new Date();
+      return date > currentDate;
     },
     isDateAndValueTheSame() {
       if (!this.date && !this.value) {

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -109,7 +109,6 @@ export default {
         formatDate: this.formatDate,
         editable: !this.disabled,
         use12HourClock: this.datepicker,
-        startPeriod: this.parseMinDate(this.minDate),
         isDateDisabled: this.isFutureDate
       };
     },
@@ -229,9 +228,16 @@ export default {
       return { month, year };
     },
     isFutureDate(date) {
-      console.log("date isFutureDate", date);
-      const currentDate = new Date();
-      return date > currentDate;
+      const minDate = !!this.minDate ? new Date(this.minDate) : "";
+      const maxDate = !!this.maxDate ? new Date(this.maxDate) : "";
+      if (minDate.length === 0 && maxDate.length === 0) return;
+      if (!!minDate && !!maxDate) {
+        return !(date >= minDate && date <= maxDate);
+      }
+      console.log(`minDate is ${minDate}`);
+      console.log(`maxDate is ${maxDate}`);
+      if (!!minDate && maxDate.length === 0) return date < minDate;
+      if (minDate.length === 0 && !!maxDate) return date > maxDate;
     },
     isDateAndValueTheSame() {
       if (!this.date && !this.value) {

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -8,6 +8,7 @@
       :data-test="dataTest"
       :class="classList"
       :input-attributes="inputAttributes"
+      @input="submitDate"
     />
     <div v-if="errors.length > 0" class="invalid-feedback d-block">
       <div v-for="(err, index) in errors" :key="index">{{ err }}</div>
@@ -94,8 +95,8 @@ export default {
         class: `${this.inputClass}`,
         placeholder: this.placeholder,
         name: this.name,
-        ariaLabel: this.ariaLabel,
-        tabIndex: this.tabIndex
+        "aria-label": this.ariaLabel,
+        "tab-index": this.tabIndex
       }
     };
   },
@@ -226,6 +227,17 @@ export default {
       }
 
       return date;
+    },
+    submitDate() {
+      if (this.value && !this.date) {
+        this.$emit("input", "");
+      }
+      if (this.isDateAndValueTheSame()) return;
+      const newDate =
+        this.dataFormat === "date"
+          ? moment.utc(this.date, this.config.format)
+          : moment(this.date, this.config.format);
+      this.$emit("input", newDate.toISOString());
     }
   }
 };

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="form-group position-relative">
-    <label v-uni-for="name">{{label}}</label>
-    <date-picker
+    <label v-uni-for="name">{{ label }}</label>
+    <date-pick
       v-model="date"
       :config="config"
       :disabled="disabled"
@@ -12,57 +12,66 @@
       :class="classList"
     />
     <div v-if="errors.length > 0" class="invalid-feedback d-block">
-      <div v-for="(error, index) in errors" :key="index">{{error}}</div>
+      <div v-for="(error, index) in errors" :key="index">{{ error }}</div>
     </div>
-    <small v-if="helper" class="form-text text-muted">{{helper}}</small>
+    <small v-if="helper" class="form-text text-muted">{{ helper }}</small>
   </div>
 </template>
 
 <script>
-import { createUniqIdsMixin } from 'vue-uniq-ids';
-import ValidationMixin from './mixins/validation';
+import { createUniqIdsMixin } from "vue-uniq-ids";
+import DatePick from "vue-date-pick";
+import moment from "moment-timezone";
+import Mustache from "mustache";
+import ValidationMixin from "./mixins/validation";
 import DataFormatMixin from "./mixins/DataFormat";
-import datePicker from 'vue-bootstrap-datetimepicker';
-import moment from 'moment-timezone';
-import { getLang, getUserDateFormat, getUserDateTimeFormat } from '../dateUtils';
-import Mustache from 'mustache';
-let Validator = require('validatorjs');
+import {
+  getLang,
+  getUserDateFormat,
+  getUserDateTimeFormat
+} from "../dateUtils";
+import "vue-date-pick/dist/vueDatePick.css";
+
+const Validator = require("validatorjs");
 
 const uniqIdsMixin = createUniqIdsMixin();
-const checkFormats = ['YYYY-MM-DD', moment.ISO_8601];
+const checkFormats = ["YYYY-MM-DD", moment.ISO_8601];
 
-Validator.register('date_or_mustache', function(value, requirement, attribute) {
-  let rendered = null;
-  try {
-    // Clear out any mustache statements
-    rendered = Mustache.render(value, {});
-  } catch (e) {
-    rendered = value;
-  }
+Validator.register(
+  "date_or_mustache",
+  function (value, requirement, attribute) {
+    let rendered = null;
+    try {
+      // Clear out any mustache statements
+      rendered = Mustache.render(value, {});
+    } catch (e) {
+      rendered = value;
+    }
 
-  if (value !== rendered) {
-    // contains mustache, so just give them the benefit of the doubt here
-    return true;
-  }
+    if (value !== rendered) {
+      // contains mustache, so just give them the benefit of the doubt here
+      return true;
+    }
 
-  if (value === '') {
-    // Empty is ok, it just disables min/max
-    return true;
-  }
+    if (value === "") {
+      // Empty is ok, it just disables min/max
+      return true;
+    }
 
-  if (moment(value, checkFormats, true).isValid()) {
-    return true;
-  }
+    if (moment(value, checkFormats, true).isValid()) {
+      return true;
+    }
 
-  return false;
-
-}, 'Must be YYYY-MM-DD, ISO8601, or mustache syntax');
+    return false;
+  },
+  "Must be YYYY-MM-DD, ISO8601, or mustache syntax"
+);
 
 export default {
-  mixins: [uniqIdsMixin, ValidationMixin, DataFormatMixin],
   components: {
-    datePicker
+    DatePick
   },
+  mixins: [uniqIdsMixin, ValidationMixin, DataFormatMixin],
   props: {
     name: String,
     placeholder: String,
@@ -71,31 +80,24 @@ export default {
     helper: String,
     dataFormat: String,
     value: [String, Boolean, Date],
-    inputClass: {type: [String, Array, Object], default: 'form-control'},
+    inputClass: { type: [String, Array, Object], default: "form-control" },
     dataTest: String,
     disabled: null,
     minDate: { type: [String, Boolean], default: false },
-    maxDate: { type: [String, Boolean], default: false },
+    maxDate: { type: [String, Boolean], default: false }
   },
   data() {
     return {
       validatorErrors: [],
-      date: null,
-    }
-  },
-  created() {
-    Validator.register('after_min_date', (value, requirement, attribute) => {
-      if (this.parseDate(value) < this.parseDate(this.minDate)) {
-        return false;
-      }
-      return true;
-    }, 'Must be after or equal Minimum Date');
+      date: ""
+    };
   },
   computed: {
     classList() {
       return {
-        'is-invalid': (this.validator && this.validator.errorCount) || this.error,
-      }
+        "is-invalid":
+          (this.validator && this.validator.errorCount) || this.error
+      };
     },
     errors() {
       if (this.error) {
@@ -105,52 +107,58 @@ export default {
     },
     config() {
       return {
-        format: this.dataFormat === 'datetime' ? getUserDateTimeFormat() : getUserDateFormat(),
+        format:
+          this.dataFormat === "datetime"
+            ? getUserDateTimeFormat()
+            : getUserDateFormat(),
         locale: getLang(),
         useCurrent: false,
         showClose: true,
         minDate: this.parseDate(this.minDate),
         maxDate: this.checkValidMaxDate(),
         icons: {
-          time: 'far fa-clock',
-          date: 'far fa-calendar',
-          up: 'fas fa-arrow-up',
-          down: 'fas fa-arrow-down',
-          previous: 'fas fa-chevron-left',
-          next: 'fas fa-chevron-right',
-          today: 'fas fa-calendar-check',
-          clear: 'far fa-trash-alt',
-          close: 'far fa-times-circle'
+          time: "far fa-clock",
+          date: "far fa-calendar",
+          up: "fas fa-arrow-up",
+          down: "fas fa-arrow-down",
+          previous: "fas fa-chevron-left",
+          next: "fas fa-chevron-right",
+          today: "fas fa-calendar-check",
+          clear: "far fa-trash-alt",
+          close: "far fa-times-circle"
         }
       };
-    },
+    }
   },
   watch: {
     validator: {
       deep: true,
       handler() {
-        this.validatorErrors = this.validator && this.validator.errors.get(this.name)
-          ? this.validator.errors.get(this.name)
-          : [];
-
-      },
+        this.validatorErrors =
+          this.validator && this.validator.errors.get(this.name)
+            ? this.validator.errors.get(this.name)
+            : [];
+      }
     },
     date() {
       if (this.value && !this.date) {
-        this.$emit('input', '');
+        this.$emit("input", "");
       }
 
       if (this.isDateAndValueTheSame()) {
         return;
       }
 
-      const newDate = this.dataFormat === 'date' ? moment.utc(this.date, this.config.format) : moment(this.date, this.config.format);
+      const newDate =
+        this.dataFormat === "date"
+          ? moment.utc(this.date, this.config.format)
+          : moment(this.date, this.config.format);
 
-      this.$emit('input', newDate.toISOString());
+      this.$emit("input", newDate.toISOString());
     },
     value() {
       if (!this.value) {
-        this.date = '';
+        this.date = "";
         return;
       }
 
@@ -165,13 +173,22 @@ export default {
       handler() {
         this.date = this.value
           ? this.generateDate().format(this.config.format)
-          : '';
+          : "";
       }
-    },
+    }
+  },
+  created() {
+    Validator.register(
+      "after_min_date",
+      (value, requirement, attribute) => {
+        return this.parseDate(value) >= this.parseDate(this.minDate);
+      },
+      "Must be after or equal Minimum Date"
+    );
   },
   methods: {
     checkValidMaxDate() {
-      if (this.minDate == '') {
+      if (this.minDate === "") {
         return this.parseDate(this.maxDate);
       }
       if (this.parseDate(this.maxDate) >= this.parseDate(this.minDate)) {
@@ -182,8 +199,7 @@ export default {
     parseDate(val) {
       let date = false;
 
-      if (typeof val === 'string' && val !== '') {
-
+      if (typeof val === "string" && val !== "") {
         try {
           date = Mustache.render(val, this.validationData);
         } catch (error) {
@@ -205,7 +221,7 @@ export default {
 
       const currentDate = moment(this.date, this.config.format);
       const currentValue = this.value ? moment(this.value) : null;
-      const comparatorString = this.dataFormat !== 'datetime' ? 'day' : null;
+      const comparatorString = this.dataFormat !== "datetime" ? "day" : null;
 
       return currentDate.isSame(currentValue, comparatorString);
     },
@@ -217,15 +233,7 @@ export default {
       }
 
       return date;
-    },
-  },
+    }
+  }
 };
 </script>
-
-<style>
-  @import '~pc-bootstrap4-datetimepicker/build/css/bootstrap-datetimepicker.css';
-
-  .inspector-container .bootstrap-datetimepicker-widget.dropdown-menu {
-    font-size: 11px;
-  }
-</style>

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -36,7 +36,7 @@ const checkFormats = ["YYYY-MM-DD", moment.ISO_8601];
 
 Validator.register(
   "date_or_mustache",
-  function (value, requirement, attribute) {
+  function(value, requirement, attribute) {
     let rendered = null;
     try {
       // Clear out any mustache statements
@@ -135,34 +135,12 @@ export default {
     validator: {
       deep: true,
       handler() {
-        console.log("validator errors", this.validator);
         this.validatorErrors =
           this.validator && this.validator.errors.get(this.name)
             ? this.validator.errors.get(this.name)
             : [];
-        console.log("validatorErrors", this.validatorErrors);
       }
     }
-    // value() {
-    //   if (!this.value) {
-    //     this.date = "";
-    //     return;
-    //   }
-    //
-    //   const newDate = this.generateDate(this.value);
-    //
-    //   if (!this.isDateAndValueTheSame()) {
-    //     this.date = newDate.format(this.config.format);
-    //   }
-    // },
-    // dataFormat: {
-    //   immediate: true,
-    //   handler() {
-    //     this.date = this.value
-    //       ? this.generateDate().format(this.config.format)
-    //       : "";
-    //   }
-    // }
   },
   created() {
     Validator.register(

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -7,9 +7,10 @@
       :format="format"
       :placeholder="placeholder"
       :data-test="dataTest"
-      :aria-label="$attrs['aria-label']"
-      :tabindex="$attrs['tabindex']"
+      :aria-label="ariaLabel"
+      :tabindex="tabIndex"
       :class="classList"
+      :input-attributes="inputAttributes"
     />
     <div v-if="errors.length > 0" class="invalid-feedback d-block">
       <div v-for="(err, index) in errors" :key="index">{{ err }}</div>
@@ -37,7 +38,7 @@ const checkFormats = ["YYYY-MM-DD", moment.ISO_8601];
 
 Validator.register(
   "date_or_mustache",
-  function(value, requirement, attribute) {
+  function (value, requirement, attribute) {
     let rendered = null;
     try {
       // Clear out any mustache statements
@@ -74,14 +75,19 @@ export default {
     helper: String,
     dataFormat: String,
     value: [String, Boolean, Date],
+    ariaLabel: String,
+    tabIndex: Number,
     inputClass: { type: [String, Array, Object], default: "form-control" },
-    dataTest: String,
+    dataTest: {
+      type: String,
+      default: "date-picker"
+    },
     disabled: {
       type: Boolean,
       default: false
     },
     minDate: { type: [String, Boolean], default: false },
-    maxDate: { type: [String, Boolean], default: false },
+    maxDate: { type: [String, Boolean], default: false }
   },
   data() {
     return {
@@ -89,16 +95,21 @@ export default {
       date: "",
       datepicker: this.dataFormat === "datetime",
       format: this.datepicker ? getUserDateTimeFormat() : getUserDateFormat(),
-      config: {
+      inputAttributes: {
+        class: `${this.inputClass}`
+      }
+    };
+  },
+  computed: {
+    config() {
+      return {
         format: this.format,
         pickTime: this.datepicker,
         parseDate: this.parseDate,
         formatDate: this.formatDate,
         editable: !this.disabled
-      }
-    };
-  },
-  computed: {
+      };
+    },
     classList() {
       return {
         "is-invalid":

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -250,3 +250,9 @@ export default {
   }
 };
 </script>
+
+<style>
+.vdpHeadCell {
+  padding: 0.3em 0.4em 1.8em;
+}
+</style>

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -1,10 +1,9 @@
 <template>
   <div class="form-group position-relative">
-    <label v-uni-for="name">{{ label }}</label>
+    <label v-uni-for="name" class="mr-2">{{ label }}</label>
     <date-pick
       v-model="date"
-      :config="config"
-      :disabled="disabled"
+      v-bind="config"
       :placeholder="placeholder"
       :data-test="dataTest"
       :aria-label="$attrs['aria-label']"
@@ -12,7 +11,7 @@
       :class="classList"
     />
     <div v-if="errors.length > 0" class="invalid-feedback d-block">
-      <div v-for="(error, index) in errors" :key="index">{{ error }}</div>
+      <div v-for="(err, index) in errors" :key="index">{{ err }}</div>
     </div>
     <small v-if="helper" class="form-text text-muted">{{ helper }}</small>
   </div>
@@ -25,11 +24,7 @@ import moment from "moment-timezone";
 import Mustache from "mustache";
 import ValidationMixin from "./mixins/validation";
 import DataFormatMixin from "./mixins/DataFormat";
-import {
-  getLang,
-  getUserDateFormat,
-  getUserDateTimeFormat
-} from "../dateUtils";
+import { getUserDateFormat, getUserDateTimeFormat } from "../dateUtils";
 import "vue-date-pick/dist/vueDatePick.css";
 
 const Validator = require("validatorjs");
@@ -58,11 +53,7 @@ Validator.register(
       return true;
     }
 
-    if (moment(value, checkFormats, true).isValid()) {
-      return true;
-    }
-
-    return false;
+    return moment(value, checkFormats, true).isValid();
   },
   "Must be YYYY-MM-DD, ISO8601, or mustache syntax"
 );


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
The new date picker should replicate the same functionality as the old one

## Solution
- Implemented the new date picker
- Change some functions and cleaned the code

## How to Test
* Run `npm run serve` and start playing in the background.
I would recommend linking this package to `screen-builder` and test it with the functionality there.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6854
- https://github.com/ProcessMaker/screen-builder/pull/1311

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
