### PR TITLE
FOUR-6996: Text Area Field Improvements

### DIFF
--- a/src/components/FormTextArea.vue
+++ b/src/components/FormTextArea.vue
@@ -72,7 +72,8 @@ export default {
         icon: this.$attrs.icon,
         placeholder: this.$attrs.placeholder,
         "aria-label": this.$attrs["aria-label"],
-        "data-cy": this.$attrs["data-cy"]
+        "data-cy": this.$attrs["data-cy"],
+        tabindex: this.$attrs.tabindex
       },
       editorSettings: {
         inline: false,
@@ -152,7 +153,6 @@ export default {
       if (!this.editorInstance) {
         return;
       }
-
       if (!this.rows) {
         return;
       }

--- a/src/components/FormTextArea.vue
+++ b/src/components/FormTextArea.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="form-group">
     <label v-uni-for="label">{{ label }} </label>
-    <!-- {{ $attrs }} -->
     <div v-if="richtext" :class="classList" v-uni-id="label">
       <div v-if="readonly" v-html="value"></div>
       <div v-else>

--- a/src/components/FormTextArea.vue
+++ b/src/components/FormTextArea.vue
@@ -1,13 +1,14 @@
 <template>
   <div class="form-group">
-  <label v-uni-for="label">{{label}}</label>
+    <label v-uni-for="label">{{ label }} </label>
+    <!-- {{ $attrs }} -->
     <div v-if="richtext" :class="classList" v-uni-id="label">
       <div v-if="readonly" v-html="value"></div>
       <div v-else>
         <editor
-          class="editor"
           v-if="!readonly && editorActive"
-          v-bind="$attrs"
+          class="editor"
+          v-bind="objectOfAttrs"
           :value="value"
           :init="editorSettings"
           :name="name"
@@ -17,63 +18,109 @@
     </div>
     <textarea
       v-else
-      v-bind="$attrs"
+      v-uni-id="label"
+      v-bind="objectOfAttrs"
+      class="form-control"
       :rows="rows"
       :readonly="readonly"
-      v-uni-id="label"
-      class="form-control"
       :class="classList"
       :name="name"
       :value="value"
       @input="$emit('input', $event.target.value)"
     />
-    <display-errors v-if="error || (validator && validator.errorCount)" :name="name" :error="error" :validator="validator"/>
-    <small v-if='helper' class='form-text text-muted'>{{helper}}</small>
+    <display-errors
+      v-if="error || (validator && validator.errorCount)"
+      :name="name"
+      :error="error"
+      :validator="validator"
+    />
+    <small v-if="helper" class="form-text text-muted">{{ helper }}</small>
   </div>
 </template>
 
 <script>
-import { createUniqIdsMixin } from 'vue-uniq-ids'
-import ValidationMixin from './mixins/validation'
-import DataFormatMixin from './mixins/DataFormat';
-import DisplayErrors from './common/DisplayErrors';
-import Editor from './Editor'
-import throttle from 'lodash/throttle';
+import { createUniqIdsMixin } from "vue-uniq-ids";
+import throttle from "lodash/throttle";
+import ValidationMixin from "./mixins/validation";
+import DataFormatMixin from "./mixins/DataFormat";
+import DisplayErrors from "./common/DisplayErrors";
+import Editor from "./Editor";
 
 const uniqIdsMixin = createUniqIdsMixin();
 
 export default {
-  inheritAttrs: false,
   components: {
     DisplayErrors,
     Editor
   },
   mixins: [uniqIdsMixin, ValidationMixin, DataFormatMixin],
-
+  inheritAttrs: false,
   props: [
-    'label',
-    'error',
-    'name',
-    'value',
-    'helper',
-    'controlClass',
-    'richtext',
-    'readonly',
-    'rows'
+    "label",
+    "error",
+    "name",
+    "value",
+    "helper",
+    "controlClass",
+    "richtext",
+    "readonly",
+    "rows"
   ],
+  data() {
+    return {
+      objectOfAttrs: {
+        icon: this.$attrs.icon,
+        placeholder: this.$attrs.placeholder,
+        "aria-label": this.$attrs["aria-label"],
+        "data-cy": this.$attrs["data-cy"]
+      },
+      editorSettings: {
+        inline: false,
+        statusbar: false,
+        content_style:
+          "body { font-family: Arial; } .pagebreak { border: 1px solid #ccc; }",
+        menubar: false,
+        plugins: ["link", "lists", "image"],
+        toolbar: `undo redo | link image pagebreak | styleselect | bold italic forecolor |
+           alignleft aligncenter alignright alignjustify | bullist numlist outdent indent`,
+        skin: false,
+        content_css: false,
+        relative_urls: false,
+        remove_script_host: false,
+        init_instance_callback: (editor) => {
+          this.editorInstance = editor;
+          this.setHeight();
+        },
+        setup: (editor) => {
+          editor.ui.registry.addButton("pagebreak", {
+            tooltip: this.$t("Insert Page Break For PDF"),
+            icon: "page-break",
+            onAction: function (_) {
+              editor.insertContent(
+                "<hr class='pagebreak' style='page-break-after: always;' />"
+              );
+            }
+          });
+        }
+      },
+      editorInstance: null,
+      editorActive: true
+    };
+  },
   computed: {
     classList() {
       return {
-        'is-invalid': (this.validator && this.validator.errorCount) || this.error,
+        "is-invalid":
+          (this.validator && this.validator.errorCount) || this.error,
         [this.controlClass]: !!this.controlClass,
-        'richtext': this.richtext && !this.readonly,
+        richtext: this.richtext && !this.readonly
       };
     },
     height() {
       if (!this.rows) {
         return false;
       }
-      return String(parseInt(this.rows) * 55) + 'px';
+      return String(parseInt(this.rows) * 55) + "px";
     }
   },
   watch: {
@@ -81,22 +128,22 @@ export default {
       handler() {
         this.setHeight();
       },
-      immediate: true,
+      immediate: true
     },
     name() {
       this.rebootEditor();
-    },
+    }
   },
   created() {
     this.rebootEditor = throttle(() => {
       this.editorActive = false;
       this.$nextTick(() => {
-        this.editorActive = true
+        this.editorActive = true;
       });
     }, 500);
   },
   mounted() {
-    window.ProcessMaker.EventBus.$on('modal-shown', () => {
+    window.ProcessMaker.EventBus.$on("modal-shown", () => {
       this.rebootEditor();
     });
   },
@@ -109,43 +156,15 @@ export default {
       if (!this.rows) {
         return;
       }
-      if (this.editorInstance.getContainer() && this.editorInstance.getContainer().style) {
-          this.editorInstance.getContainer().style.height = this.height;
+      if (
+        this.editorInstance.getContainer() &&
+        this.editorInstance.getContainer().style
+      ) {
+        this.editorInstance.getContainer().style.height = this.height;
       }
     }
-  },
-  data() {
-    return {
-      editorSettings: {
-        inline: false,
-        statusbar: false,
-        content_style: 'body { font-family: Arial; } .pagebreak { border: 1px solid #ccc; }',
-        menubar: false,
-        plugins: [ 'link', 'lists', 'image'],
-        toolbar: 'undo redo | link image pagebreak | styleselect | bold italic forecolor | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent',
-        skin: false,
-        content_css: false,
-        relative_urls: false,
-        remove_script_host: false,
-        init_instance_callback: (editor) => {
-          this.editorInstance = editor;
-          this.setHeight();
-        },
-        setup: (editor) => {
-          editor.ui.registry.addButton('pagebreak', {
-            tooltip: this.$t('Insert Page Break For PDF'),
-            icon: 'page-break',
-            onAction: function (_) {
-              editor.insertContent("<hr class='pagebreak' style='page-break-after: always;' />");
-            }
-          });
-        },
-      },
-      editorInstance: null,
-      editorActive: true,
-    }
   }
-}
+};
 </script>
 
 <style lang="scss">

--- a/src/components/FormTextArea.vue
+++ b/src/components/FormTextArea.vue
@@ -68,7 +68,6 @@ export default {
   data() {
     return {
       objectOfAttrs: {
-        icon: this.$attrs.icon,
         placeholder: this.$attrs.placeholder,
         "aria-label": this.$attrs["aria-label"],
         "data-cy": this.$attrs["data-cy"],


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Improve to text area field

## Solution
- [x] Remove all the watch declarations if possible. Manly the ones that could use the deep: true flag
- [x] Remove all the computed properties if possible. Only the ones that really need to be reactive could be kept. It is better to evaluate then on data() create() * or mount()
- [x] Remove the v-bind="$attrs" if possible, it is better to define all the properties that the control can use including testing ones like data-cy
- [x] Avoid the use of transientData if possible.
- [x] v-if can reduce the reactivity (more than v-show) if it contains multiple reactive elements inside
- [x] Make sure v-for also includes a proper :key
- [X] Avoid the use of code like {... this.reactiveObject }e.g. { ...this.transientData } because it triggers the reactivity from all the properties of reactiveObject.

## How to Test
* Run `npm run serve` and start playing in the background.
I would recommend linking this package to `screen-builder` and test it with the functionality there.

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-6996
- https://github.com/ProcessMaker/screen-builder/pull/1315

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

