### PR TITLE
FOUR-7559: Fixed datepicker input not being responsive

### DIFF
--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -6,7 +6,7 @@
       v-bind="config"
       :format="format"
       :data-test="dataTest"
-      :class="classList"
+      :class="[classList, 'datePicker']"
       :input-attributes="inputAttributes"
       @input="submitDate"
     />
@@ -254,5 +254,8 @@ export default {
 <style>
 .vdpHeadCell {
   padding: 0.3em 0.4em 1.8em;
+}
+.datePicker {
+  display: block;
 }
 </style>


### PR DESCRIPTION
## Issue & Reproduction Steps
The date picker component is not responsive as other controls and it doesn't look good on the design the screen.
 
1. Create screen 
2. Add line input 
3. Add date picker
4. Press preview button

Expected behavior: 
The date picker component should be responsive, the same with others controls, the label should be at the top.

Actual behavior: 
The date picker input is displayed next to its' label either in design mode or in preview mode.

## Solution
- A new class (`.datePicker`) on the FormDatePicker.vue file was added to the date-picker input. This was done to change the css property: `display: inline-block` that was causing the issue. The display mode was changed to `block` to match the other inputs.

## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7559
- https://github.com/ProcessMaker/screen-builder

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
