### PR TITLE
FOUR-7564 Date picker does not validate the correct format

### DIFF
--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -22,8 +22,10 @@
         />
         <button
           v-if="date"
-          type="button" @click="clear" class="vdpClearInput">
-        </button>
+          type="button"
+          @click="clear"
+          class="vdpClearInput"
+        ></button>
       </template>
     </date-pick>
     <div v-if="errors.length > 0" class="invalid-feedback d-block">
@@ -254,14 +256,13 @@ export default {
       return currentDate.isSame(currentValue, comparatorString);
     },
     submitDate() {
-      debugger;
-      if(this.onChangeDate !== "") {
+      if (this.onChangeDate !== "") {
         this.date = this.onChangeDate;
       }
       if (this.value && !this.date) {
         this.$emit("input", "");
       }
-      
+
       if (this.isDateAndValueTheSame()) return;
       const newDate =
         this.dataFormat === "date"
@@ -273,18 +274,21 @@ export default {
       if (this.parseDateToDate(this.maxDate) > newDate) return null;
       this.$emit("input", newDate.toISOString());
     },
-    onOpen(open){
-      this.changeDate = "";
-      open();
+    onOpen(open) {
+      this.onChangeDate = "";
+      if (typeof open === "function") {
+        open();
+      }
     },
     clear() {
       this.date = "";
     },
     onChangeHandler(userText) {
-      debugger;
       if (userText) {
-        if (moment(userText, checkFormats , true).isValid()) {
-          this.onChangeDate = userText;
+        const userDate = moment(userText, [...checkFormats, this.format], true);
+        if (userDate.isValid()) {
+          this.onChangeDate = userDate.format(this.format);
+          this.submitDate();
         }
       }
     }

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -128,7 +128,7 @@ export default {
         format: this.format,
         displayFormat: this.format,
         pickTime: this.datepicker,
-
+        parseDate: this.parsingInputDate,
         editable: !this.disabled,
         use12HourClock: this.datepicker,
         isDateDisabled: this.checkMinMaxDateDisabled
@@ -169,15 +169,15 @@ export default {
       "after_min_date",
       (value, requirement, attribute) => {
         return (
-          this.parseDate(value, checkFormats) >=
-          this.parseDate(this.minDate, checkFormats)
+          this.parseDate(value) >=
+          this.parseDate(this.minDate)
         );
       },
       "Must be after or equal Minimum Date"
     );
   },
   methods: {
-    parseDate(val, format) {
+    parseDate(val) {
       let date = false;
 
       if (typeof val === "string" && val !== "") {
@@ -187,7 +187,7 @@ export default {
           date = val;
         }
 
-        date = moment(date, format, true);
+        date = moment(date, checkFormats, true);
         if (!date.isValid()) {
           date = false;
         }

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -16,8 +16,8 @@
           v-bind="inputAttributes"
           :value="inputValue"
           class="form-control"
-          @focus="open()"
-          @click="open()"
+          @focus="onOpen(open)"
+          @click="onOpen(open)"
           @change="onChangeHandler($event.target.value)"
         />
         <button
@@ -48,7 +48,7 @@ import "vue-date-pick/dist/vueDatePick.css";
 const Validator = require("validatorjs");
 
 const uniqIdsMixin = createUniqIdsMixin();
-const checkFormats = ["YYYY-MM-DD", moment.ISO_8601];
+const checkFormats = ["YYYY-MM-DD", "MM/DD/YYYY", moment.ISO_8601];
 
 Validator.register(
   "date_or_mustache",
@@ -116,7 +116,8 @@ export default {
         name: this.name,
         "aria-label": this.ariaLabel,
         "tab-index": this.tabIndex
-      }
+      },
+      onChangeDate: ""
     };
   },
   computed: {
@@ -125,7 +126,7 @@ export default {
         format: this.format,
         displayFormat: this.format,
         pickTime: this.datepicker,
-        parseDate: this.parsingInputDate,
+
         editable: !this.disabled,
         use12HourClock: this.datepicker,
         isDateDisabled: this.checkMinMaxDateDisabled
@@ -213,6 +214,7 @@ export default {
       return date;
     },
     parsingInputDate(val) {
+      debugger;
       const date = moment(val, this.format, true);
       // Check if user is typing, if the date is not valid, let the user continue
       if (!date.isValid()) return "";
@@ -252,9 +254,14 @@ export default {
       return currentDate.isSame(currentValue, comparatorString);
     },
     submitDate() {
+      debugger;
+      if(this.onChangeDate !== "") {
+        this.date = this.onChangeDate;
+      }
       if (this.value && !this.date) {
         this.$emit("input", "");
       }
+      
       if (this.isDateAndValueTheSame()) return;
       const newDate =
         this.dataFormat === "date"
@@ -266,14 +273,18 @@ export default {
       if (this.parseDateToDate(this.maxDate) > newDate) return null;
       this.$emit("input", newDate.toISOString());
     },
+    onOpen(open){
+      this.changeDate = "";
+      open();
+    },
     clear() {
       this.date = "";
     },
     onChangeHandler(userText) {
+      debugger;
       if (userText) {
-        const userDate = this.parseDate(userText, this.config.format);
-        if (userDate) {
-          this.date = userDate;
+        if (moment(userText, checkFormats , true).isValid()) {
+          this.onChangeDate = userText;
         }
       }
     }

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -216,7 +216,6 @@ export default {
       return date;
     },
     parsingInputDate(val) {
-      debugger;
       const date = moment(val, this.format, true);
       // Check if user is typing, if the date is not valid, let the user continue
       if (!date.isValid()) return "";


### PR DESCRIPTION
## Issue & Reproduction Steps
The date picker component is not validating if the usere enter invalid characters in the input field
 
1. Create screen 
2. Add line input 
3. Add date picker
4. Press preview button
5. Select a date from widget
6. edit and enter wrong dates to the input 

Expected behavior: 
The date picker component should validate the wrong entered characters .

Actual behavior: 
The date picker input allow none formatted date 

## Solution
- on Change handler was improved to catch and validate the input string and evaluate if is a valid date
## How to Test
Test the steps above

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7564

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
