### PR TITLE
FOUR-7610 Removed v-once since the Component is not being unmounted (Datepicker)

### DIFF
--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -13,7 +13,7 @@
     <div v-if="errors.length > 0" class="invalid-feedback d-block">
       <div v-for="(err, index) in errors" :key="index">{{ err }}</div>
     </div>
-    <small v-if="helper" v-once class="form-text text-muted">{{
+    <small v-if="helper" class="form-text text-muted">{{
       helper
     }}</small>
   </div>


### PR DESCRIPTION
## Issue & Reproduction Steps

Expected behavior: 
Helper text should update by data binding

Actual behavior: 
Helper text is not updating since `v-once` is in the component helper.

## Solution
- Removing the `v-once`

## How to Test
Test the steps above
- Run VFE and add a helper text to the Datepicker
- Make sure your helper text is showing
- Make a second change to the helper text
- Make sure your new change is implemented
Added a E2E coverage https://github.com/ProcessMaker/screen-builder/pull/1347

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7610

## Code Review Checklist
- [x] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [x] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [x] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [x] This solution fixes the bug reported in the original ticket.
- [x] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [x] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [x] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [x] This ticket conforms to the PRD associated with this part of ProcessMaker.
