### PR TITLE
FIX: The date time control is showing a date before the selected one

### DIFF
--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -163,6 +163,7 @@ export default {
     value(valuee) {
       if (!!valuee && valuee.length > 0) {
         const date = moment(valuee, checkFormats, true);
+        if (!date.isValid()) return "";
         this.date = date.format(this.format);
       }
     }

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -10,7 +10,7 @@
       :input-attributes="inputAttributes"
       @input="submitDate"
     >
-      <template v-slot:default="{ open, inputValue, inputAttributes }">
+      <template v-slot:default="{ open, inputValue }">
         <input
           type="text"
           v-bind="inputAttributes"
@@ -102,6 +102,10 @@ export default {
       type: Boolean,
       default: false
     },
+    readonly: {
+      type: Boolean,
+      default: false
+    },
     minDate: { type: [String, Boolean], default: false },
     maxDate: { type: [String, Boolean], default: false }
   },
@@ -114,7 +118,9 @@ export default {
         placeholder: this.placeholder,
         name: this.name,
         "aria-label": this.ariaLabel,
-        "tab-index": this.tabIndex
+        "tab-index": this.tabIndex,
+        disabled: this.disabled,
+        readonly: this.readonly
       },
       onChangeDate: ""
     };

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -108,10 +108,7 @@ export default {
   data() {
     return {
       validatorErrors: [],
-      date:
-        !!this.value && this.value.length > 0
-          ? this.parsingInputDate(this.value)
-          : "",
+      date: "",
       inputAttributes: {
         class: `${this.inputClass}`,
         placeholder: this.placeholder,
@@ -161,6 +158,12 @@ export default {
           this.validator && this.validator.errors.get(this.name)
             ? this.validator.errors.get(this.name)
             : [];
+      }
+    },
+    value(valuee) {
+      if (!!valuee && valuee.length > 0) {
+        const date = moment(valuee, checkFormats, true);
+        this.date = date.format(this.format);
       }
     }
   },


### PR DESCRIPTION
## Issue & Reproduction Steps
The date picker component is selecting a time with a different timezone of the user.
 
Expected behavior: 
The date picker component must select the time with the timezone of the user.

Actual behavior: 
The date picker component is selecting a time with a different timezone of the user.

## Solution
- Set the timezone when retrieve and before update the datetime.

## How to Test
- Set a timezone for the user different to the browser one.
- Open any screen with datetime picker
- Ticket a date and a time
- The stored timetime in UTC must be the equivalent of the select time for the user's timezone

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-7640
- Requires: https://github.com/ProcessMaker/vue-form-elements/pull/386

- 
## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.
