### PR TITLE
FOUR-9039 DataFormat is not required for textarea

### DIFF
--- a/src/components/FormTextArea.vue
+++ b/src/components/FormTextArea.vue
@@ -41,6 +41,7 @@
 <script>
 import { createUniqIdsMixin } from "vue-uniq-ids";
 import throttle from "lodash/throttle";
+import ValidationMixin from "./mixins/validation";
 import DisplayErrors from "./common/DisplayErrors";
 import Editor from "./Editor";
 import RequiredAsterisk from './common/RequiredAsterisk';
@@ -53,7 +54,7 @@ export default {
     Editor,
     RequiredAsterisk,
   },
-  mixins: [uniqIdsMixin],
+  mixins: [uniqIdsMixin, ValidationMixin],
   inheritAttrs: false,
   props: [
     "label",

--- a/src/components/FormTextArea.vue
+++ b/src/components/FormTextArea.vue
@@ -41,8 +41,6 @@
 <script>
 import { createUniqIdsMixin } from "vue-uniq-ids";
 import throttle from "lodash/throttle";
-import ValidationMixin from "./mixins/validation";
-import DataFormatMixin from "./mixins/DataFormat";
 import DisplayErrors from "./common/DisplayErrors";
 import Editor from "./Editor";
 import RequiredAsterisk from './common/RequiredAsterisk';
@@ -55,7 +53,7 @@ export default {
     Editor,
     RequiredAsterisk,
   },
-  mixins: [uniqIdsMixin, ValidationMixin, DataFormatMixin],
+  mixins: [uniqIdsMixin],
   inheritAttrs: false,
   props: [
     "label",


### PR DESCRIPTION
The textarea field will always return a string type value, then there is no need to include DataFormat mixin.
Also the Validation mixin is an old code, that should not be used.