### PR TITLE
DataFormat is not required for textarea

### DIFF
--- a/src/components/FormTextArea.vue
+++ b/src/components/FormTextArea.vue
@@ -35,7 +35,6 @@
 <script>
 import { createUniqIdsMixin } from 'vue-uniq-ids'
 import ValidationMixin from './mixins/validation'
-import DataFormatMixin from './mixins/DataFormat';
 import DisplayErrors from './common/DisplayErrors';
 import Editor from './Editor'
 import throttle from 'lodash/throttle';
@@ -48,7 +47,7 @@ export default {
     DisplayErrors,
     Editor
   },
-  mixins: [uniqIdsMixin, ValidationMixin, DataFormatMixin],
+  mixins: [uniqIdsMixin, ValidationMixin],
 
   props: [
     'label',


### PR DESCRIPTION
Originally authored by @caleeli: "The textarea field will always return a string type value, then there is no need to include DataFormat mixin. Also the Validation mixin is an old code, that should not be used."