### PR TITLE
Bugfix/FOUR-9382: WEBPACK_IMPORTED_MODULE_2 in Summer-alpha5

### DIFF
--- a/src/components/mixins/validation.js
+++ b/src/components/mixins/validation.js
@@ -21,7 +21,7 @@ export default {
             }
         },
         required() {
-            for (const validation of get(this.config, 'validation', [])) {
+            for (const validation of get(this.config, 'validation', []) || []) {
                 const rule = get(validation, 'value', '').split(':')[0];
 
                 if (rule === 'required') {


### PR DESCRIPTION
## Issue & Reproduction Steps
When running a request and opening a task that contains screen builder elements using required-asterisk the console show an error.

**Steps to Reproduce**
- Create a simple process with a task
- Create a screen with an input (you can test input, textarea, checkbox, select list, date picker)
- Run a request
- Open the task

**Current behavior**
An error: WEBPACK_IMPORTED_MODULE_2 shows in the console 

## Solution
- In valdiations file, return an empty array if null.

## How to Test
- Follow steps above

## Related Tickets & Packages
- [FOUR-9382](https://processmaker.atlassian.net/browse/FOUR-9382)

[FOUR-9382]: https://processmaker.atlassian.net/browse/FOUR-9382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ