### PR TITLE
QA Observation bugfix/FOUR-14948: Clear Task Button in Inbox Rules page does not clear Date and Datetime fields

### DIFF
--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -188,6 +188,12 @@ export default {
   },
   methods: {
     updateValue(newValue) {
+      // allow to send empty value or null to Date and Datetime fields
+      if (newValue === null || newValue === undefined) {
+        this.$set(this, "date", '');
+        return;
+      }
+
       if (!!newValue && newValue.length > 0) {
         const date = moment.tz(newValue, checkFormats, true, getTimezone());
         if (!date.isValid()) return "";


### PR DESCRIPTION
## How to Test
Select a Task
Go to Inbox Rules
Select "Save and reuse fill data"
Press NEXT button
Click on Quick Fill button
Select a previous task and press Use This Task Data
Click on "Clear Task" button.

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-14948

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:next