### PR TITLE
FOUR-14237 Fix Iris Bank Problem with TAG a href

### DIFF
--- a/src/components/FormHtmlEditor.vue
+++ b/src/components/FormHtmlEditor.vue
@@ -64,6 +64,7 @@ export default {
            alignleft aligncenter alignright alignjustify | bullist numlist outdent indent`,
         skin: false,
         relative_urls: false,
+        convert_urls: false,
         remove_script_host: false
       }
     };


### PR DESCRIPTION
## Fix Iris Bank Problem with TAG a href
Steps to Reproduce:
1. log in ProcessMaker, go to Designer click on +screen
2. create a new screen type EMAIL
3. use a Rich text with <a href="{{ABC}}"> LINK </a>
4. now click on the element you see a menu click on HREF

## Current Behavior:

You will see that the domain URL is automatically filled in, and if you click on CANCEL you will see that the URL is applied to the element href

## Expected Behavior:

It should detect that the href is not empty and should not add anything.

## Related tickets
- https://processmaker.atlassian.net/browse/FOUR-14237

ci:next
ci:deploy
