### PR TITLE
Bugfix/FOUR-14264: Click on labels of Radio/Checkbox Group and the option select always will be the first option

### DIFF
--- a/src/components/FormSelectList/OptionboxView.vue
+++ b/src/components/FormSelectList/OptionboxView.vue
@@ -1,17 +1,17 @@
 <template>
   <form>
-    <div :class="divClass" :key="getOptionValue(option)" v-for="option in options">
+    <div :class="divClass" :key="getOptionValue(option)" v-for="(option, index) in options">
       <input
           :class="inputClass"
           type="radio"
-          v-uni-id="getOptionId(option)"
+          v-uni-id="getOptionId(option, index)"
           :name="`${name}`"
           :value="emitObjects ? option : getOptionValue(option)"
           v-model="selected"
           v-bind="$attrs"
           :disabled="isReadOnly"
       >
-      <label :class="labelClass" v-uni-for="getOptionId(option)">
+      <label :class="labelClass" v-uni-for="getOptionId(option, index)">
         {{getOptionContent(option)}}
       </label>
     </div>
@@ -77,8 +77,8 @@ export default {
     getOptionContent(option) {
       return option[this.optionContent || 'content'];
     },
-    getOptionId(option) {
-      return `${this.name}-${this.getOptionValue(option)}`;
+    getOptionId(option, index) {
+      return `${this.name}-${this.getOptionValue(option)}-${index}`;
     }
   }
 }


### PR DESCRIPTION
## Description and reproduction steps

Please relate to the ticket [FOUR-14264](https://processmaker.atlassian.net/browse/FOUR-14264) for full description, take a look to the comments.

Quick note to reproduce:
- Import the screen attached in the ticket
- Select the right select list (REQUEST DATA select list) in designer mode
- In data source in the inspector change **Type of Value Returned** from **Object** to **Single value**
- After change to single value remove the content of **Variable Data Property**
- In data source in the inspector change **Type of Value Returned** to **Object** again
- Go to design mode and click on the labels (not the dots) of the request data select list component

## Solution
- Add an unique index to the option elements in the **label tag** in the **for** attribute.

## Related tickets
- [FOUR-14264](https://processmaker.atlassian.net/browse/FOUR-14264)


[FOUR-14264]: https://processmaker.atlassian.net/browse/FOUR-14264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-14264]: https://processmaker.atlassian.net/browse/FOUR-14264?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ