### PR TITLE
Bugfix/FOUR-15004: PMQL in record list doesnt work with pm variables

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -92,8 +92,7 @@ export default {
     "controlClass",
     "validationData",
     "placeholder",
-    "multiple",
-    'transientData'
+    "multiple"
   ],
   data() {
     return {

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -92,7 +92,8 @@ export default {
     "controlClass",
     "validationData",
     "placeholder",
-    "multiple"
+    "multiple",
+    'transientData'
   ],
   data() {
     return {
@@ -119,8 +120,11 @@ export default {
     collectionOptions() {
       return get(this.options, 'collectionOptions');
     },
+    isDataConnector() {
+      return get(this.options, 'dataSource') === "dataConnector";
+    },
     isCollection() {
-      return get(this.options, 'dataSource') === "collection"
+      return get(this.options, 'dataSource') === "collection";
     },
     mode() {
       return this.$root.$children[0].mode;
@@ -227,7 +231,7 @@ export default {
           }
         }
       }
-    },
+    }
   },
   methods: {
     renderPmql(pmql) {
@@ -237,6 +241,7 @@ export default {
       }
       return "";
     },
+
     /**
      * Load select list options from a data connector
      *
@@ -246,57 +251,99 @@ export default {
     async loadOptionsFromDataConnector(options) {
       const { selectedEndPoint, selectedDataSource, dataName } = options;
 
-      // If no data source has been specified, do not make the api call
-      if (
-        selectedDataSource === null ||
-        typeof selectedDataSource === "undefined" ||
-        selectedDataSource.toString().trim().length === 0
-      ) {
+      if (!this.shouldLoadOptionsFromDataConnector(selectedDataSource, selectedEndPoint)) {
         return false;
       }
 
-      // Do not run in standalone mode
-      if (!this.$dataProvider) {
+      const params = this.prepareParamsForDataConnector(selectedEndPoint);
+      const request = { selectedDataSource, params };
+
+      if (isEqual(this.lastRequest, request)) {
+        return false;
+      }
+
+      this.lastRequest = cloneDeep(request);
+
+      this.fetchDataSourceOptions(selectedDataSource, params, dataName);
+    },
+
+    shouldLoadOptionsFromDataConnector(selectedDataSource, selectedEndPoint) {
+      if (this.isEditorMode()) {
+        return false;
+      }
+
+      // If no data source has been specified, do not make the api call
+      if (this.isNoDataSourceSelected(selectedDataSource)) {
         return false;
       }
 
       // If no endpoint has been specified, do not make the api call
-      if (
-        selectedEndPoint === null ||
-        typeof selectedEndPoint === "undefined" ||
-        selectedEndPoint.toString().trim().length === 0
-      ) {
+      if (this.isNoEndpointSelected(selectedEndPoint)) {
         return false;
       }
 
+      // Do not run in standalone mode
+      if (this.isStandaloneMode()) {
+        return false;
+      }
+
+      return true;
+    },
+
+    isEditorMode() {
+      return this.mode === "editor";
+    },
+
+    isNoDataSourceSelected(dataSource) {
+      return dataSource === null || typeof dataSource === "undefined" || dataSource.toString().trim().length === 0;
+    },
+
+    isNoEndpointSelected(endpoint) {
+      return endpoint === null || typeof endpoint === "undefined" || endpoint.toString().trim().length === 0;
+    },
+
+    isStandaloneMode() {
+      return !this.$dataProvider;
+    },
+
+    prepareParamsForDataConnector(selectedEndPoint) {
       const params = {
         config: {
           endpoint: selectedEndPoint
         }
       };
 
-      if (
-        typeof this.options.pmqlQuery !== "undefined" &&
-        this.options.pmqlQuery !== "" &&
-        this.options.pmqlQuery !== null
-      ) {
-        const data = this.makeProxyData();
-        const pmql = Mustache.render(this.options.pmqlQuery, { data });
+      const pmql = this.renderPmql(this.options.pmqlQuery);
+
+      if (pmql) {
         params.config.outboundConfig = [
-          { type: "PARAM", key: "pmql", value: pmql }
+          {
+            type: "PARAM",
+            key: "pmql",
+            value: pmql
+          }
         ];
       }
-      const request = { selectedDataSource, params };
-      if (isEqual(this.lastRequest, request)) {
-        return false;
-      }
-      this.lastRequest = cloneDeep(request);
 
+      return params;
+    },
+
+    async fetchDataSourceOptions(dataSource, params, dataName) {
       try {
-        const response = await this.$dataProvider.getDataSource(
-          selectedDataSource,
-          params
-        );
+        let resolvedNonce = null;
+        let response = { data : [] };
+
+        // Nonce ensures we only use results from the latest request
+        this.nonce = Math.random();
+
+        [response, resolvedNonce] = await this.$dataProvider.getDataSource(dataSource, params, this.nonce);
+
+        if (resolvedNonce !== this.nonce) {
+          return;
+        }
+
+        this.nonce = null;
+
         const list = dataName ? get(response.data, dataName) : response.data;
         const transformedList = this.transformOptions(list);
         this.$root.$emit("selectListOptionsUpdated", transformedList);
@@ -308,6 +355,7 @@ export default {
         return false;
       }
     },
+
     async loadOptionsFromCollection() {
       if (this.mode === "editor") {
         return false;
@@ -396,7 +444,7 @@ export default {
     async getCollectionRecords(options) {
       let data = { data : [] };
       let resolvedNonce = null;
-            
+
       // Nonce ensures we only use results from the latest request
       this.nonce = Math.random();
 

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -331,7 +331,7 @@ export default {
     async fetchDataSourceOptions(dataSource, params, dataName) {
       try {
         let resolvedNonce = null;
-        let response = { data : [] };
+        let response = null;
 
         // Nonce ensures we only use results from the latest request
         this.nonce = Math.random();


### PR DESCRIPTION
## Issue & Reproduction Steps

Please see https://processmaker.atlassian.net/browse/FOUR-15004

To reproduce:
- Create a screen 
- Add an input with a default and name it **user** (you can use your custom example)
- Add a select list of type data connector (you can use the users endpoint)
- Configure Options Variable: response.data
- Type of Value Returned: Object
- Content {{data.username}}
- Data connector: Users
- Endpoint ListAll
- Add a PMQL: **data.username="{{user}}"** (user is the name of the input you added before)
- Go to preview and type some valid user in the input to make the pmql trigger and change the option list of the select

**Working video**

https://github.com/ProcessMaker/processmaker/assets/90727999/2fa1ce60-a5e5-44b8-9d45-4389aa603c6a


## Solution
- Fix PMQL render and code refactor for dataconnector
- Fix issue with cacheEnabled
- Fix NL to PMQL to call microservice for PMQL input in select lists
- Add nonce to use last call in select list dataconnector

## How to Test
- Follow steps above. You can test also type collections for data source

## Related Tickets & Packages
- [FOUR-15004](https://processmaker.atlassian.net/browse/FOUR-15004)
- [Core PR](https://github.com/ProcessMaker/processmaker/pull/6936)
- [Screen builder PR](https://github.com/ProcessMaker/screen-builder/pull/1614)
- [Vue form elements PR](https://github.com/ProcessMaker/vue-form-elements/pull/424)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:develop

[FOUR-15004]: https://processmaker.atlassian.net/browse/FOUR-15004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ