### PR TITLE
Fix Display of Selected Option Label in Radio Button Select Lists with Collections

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -261,7 +261,7 @@ export default {
     updateOption(updatedValue) {
       const index = this.selectListOptions.findIndex((option) => option.id === updatedValue.id);
       if (index !== -1) {
-        this.$set(this.selectListOptions, index, updatedValue);
+        Object.assign(this.selectListOptions[index], updatedValue);
       }
     },
     /**


### PR DESCRIPTION
This PR resolves an issue where select lists configured as radio buttons with collections did not display the selected option label. The problem was identified through a failing E2E test.

## Issue:
The issue was due to the overwriting of a particular property `__content__` within `this.selectedListOptions` when an option was selected.

## Solution:
Updated the method to use `Object.assign` instead of `this.$set` to ensure existing properties are not overwritten.

## How to Test

1. Run all E2E tests for the SelectListCollection component.
2. Follow the replication steps outlined in the ticket [FOUR-16938](https://processmaker.atlassian.net/browse/FOUR-16938).

## Related Tickets and PRs
[FOUR-16938](https://processmaker.atlassian.net/browse/FOUR-16938)

ci:next

![Uploading Screenshot 2024-07-03 at 3.35.33 PM.png…]()


[FOUR-16938]: https://processmaker.atlassian.net/browse/FOUR-16938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FOUR-16938]: https://processmaker.atlassian.net/browse/FOUR-16938?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ