### PR TITLE
Fix E2E Test Failures in SelectList Test Suites

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -109,12 +109,6 @@ export default {
       countWithoutFilter: null,
     };
   },
-  mounted() {
-    this.$root.$on("selectListOptionsUpdated", this.onSelectListOptionsUpdated);
-  },
-  beforeDestroy() {
-    this.$root.$off("selectListOptionsUpdated", this.onSelectListOptionsUpdated);
-  },
   computed: {
     selectListOptionsWithSelected() {
       if (this.selectedOption && !this.selectListOptions.some(o => o.value === this.selectedOption.value)) {
@@ -234,14 +228,6 @@ export default {
         }
       }
     },
-    value: {
-      deep: true,
-      handler(newValue) {
-        if (newValue && typeof newValue === "object" && this.isMultiSelectDisabled()) {
-          this.updateOption(newValue);
-        }
-      }
-    }
   },
   methods: {
     /**
@@ -251,26 +237,6 @@ export default {
      */
     isMultiSelectDisabled() {
       return this.options.allowMultiSelect === false;
-    },
-
-    /**
-     * Updates the specified option with the provided updated value.
-     *
-     * @param {Object} updatedValue - The updated value of the option.
-     */
-    updateOption(updatedValue) {
-      const index = this.selectListOptions.findIndex((option) => option.id === updatedValue.id);
-      if (index !== -1) {
-        this.$set(this.selectListOptions, index, updatedValue);
-      }
-    },
-    /**
-     * If the value is an object, it updates the selected option if necessary.
-     */
-    onSelectListOptionsUpdated() {
-      if (this.value && typeof this.value === "object" && this.isMultiSelectDisabled()) {
-        this.updateOption(this.value);
-      }
     },
     renderPmql(pmql) {
       if (typeof pmql !== "undefined" && pmql !== "" && pmql !== null) {
@@ -342,7 +308,6 @@ export default {
         const list = dataName ? get(response.data, dataName) : response.data;
         const transformedList = this.transformOptions(list);
         this.selectListOptions = transformedList;
-        this.$root.$emit("selectListOptionsUpdated", transformedList);
         return true;
       } catch (err) {
         /* Ignore error */


### PR DESCRIPTION
This PR removes the changes implemented in the [PR](https://github.com/ProcessMaker/vue-form-elements/pull/425) for ticket [FOUR-16319](https://processmaker.atlassian.net/browse/FOUR-16319). The initial changes caused E2E test failures in the SelectList test suites. This serves as a temporary rollback to stabilize the test suites while a more comprehensive solution is developed.


## Solution:
- Remove changes from PR for ticket FOUR-16319 to fix E2E test failures in SelectList test suites

## How to Test:

1. Execute all E2E tests, specifically focusing on the SelectList test suites.
2. Ensure that no E2E test failures occur for Select Lists.

![Screenshot 2024-07-08 at 12 15 38 PM](https://github.com/ProcessMaker/vue-form-elements/assets/52755494/3cf50958-6531-435e-8d80-84770c65a550)


[FOUR-16319]: https://processmaker.atlassian.net/browse/FOUR-16319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ