### PR TITLE
FOUR-16942 | Update Inbound Configuration Accordion Icon in Node Inspector Panel

### DIFF
--- a/src/components/FormAccordion.vue
+++ b/src/components/FormAccordion.vue
@@ -4,17 +4,14 @@
       v-b-toggle="`collapse-${config.name || config.label}`"
       class="accordion-button text-left card-header d-flex align-items-center w-100 pl-3"
       :id="`accordion-button-${config.name || config.label}`"
-      >
-        <i
-          v-if="config.icon"
-          class="fas mr-1 fa-fw"
-          :class="`fa-${config.icon}`"
-        />
-
-        <span class="ml-1 mr-auto">{{ config.label }}</span>
-
-        <i class="when-opened fas fa-chevron-down accordion-arrow ml-auto" />
-        <i class="when-closed fas fa-chevron-right accordion-arrow ml-auto" />
+    >
+      <div v-if="config.icon">
+        <i v-if="fontAwesomeIcon" class="fas mr-1 fa-fw" :class="`fa-${config.icon}`" />
+        <img v-if="svgIcon" :src="config.icon" :alt="config.name + ' icon'" width="18px" class="mr-1" />
+      </div>
+      <span class="ml-1 mr-auto">{{ config.label }}</span>
+      <i class="when-opened fas fa-chevron-down accordion-arrow ml-auto" />
+      <i class="when-closed fas fa-chevron-right accordion-arrow ml-auto" />
     </button>
 
     <b-collapse
@@ -41,7 +38,9 @@ export default {
     return {
       initiallyOpen: Boolean(this.config.initiallyOpen),
       items: [],
-    }
+      fontAwesomeIcon: false,
+      svgIcon: false,
+    };
   },
   watch: {
     value: {
@@ -54,7 +53,21 @@ export default {
       this.$emit('input', this.items);
     },
   },
-}
+  mounted() {
+    this.getAccordionIcon();
+  },
+  methods: {
+    getAccordionIcon() {
+      if (this.config.icon.includes("svg")) {
+        this.fontAwesomeIcon = false;
+        this.svgIcon = true;
+      } else {
+        this.fontAwesomeIcon = true;
+        this.svgIcon = false;
+      }
+    }
+  }
+};
 </script>
 
 <style scoped lang="scss">


### PR DESCRIPTION
# Issue
Ticket: [FOUR-16942](https://processmaker.atlassian.net/browse/FOUR-16942)

The RPA Node Inspector Panel introduced a new accordion for Inbound Configuration. To maintain consistency with other accordions, an icon was added alongside its label using the provided icon.

# Solution
- Update the `FormAccordion` component in `vue-form-elements` to handle svg icons. (Previously, it only handled Font Awesome Icons.) 
- Add the svg icon to the Inbound Configuration accordion in `package-rpa`.

# How to Test
1. Go to branch `observation/FOUR-16942` in `package-rpa` and `vue-form-elements`.
2. Go to Designer → Processes. Create a Process.
3. Open the Process in the Modeler.
4. Add the RPA Node to the Modeler canvas.
5. Click on the RPA Node. View the RPA Node Inspector Panel.
	- The Inbound Configuration accordion should have an icon. The styling of the icon should be similar to that of the other accordion icons.

ci:next

# Code Review Checklist

- [ ]  I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ]  This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ]  This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ]  This solution fixes the bug reported in the original ticket.
- [ ]  This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ]  This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ]  This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ]  This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ]  This ticket conforms to the PRD associated with this part of ProcessMaker.

[FOUR-16942]: https://processmaker.atlassian.net/browse/FOUR-16942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ