### PR TITLE
FOUR-14272: [next] Required field asterisk is not being shown if the field is inside two multicolumns

### DIFF
--- a/src/components/mixins/validation.js
+++ b/src/components/mixins/validation.js
@@ -31,7 +31,7 @@ export default {
             // Account for multicolumn components
             source = source.$parent;
           }
-          const check = get(source, variable);
+          const check = get(source, variable) || get(this.transientData, variable);
 
           if (rule === "required_if") {
             if (check == value) {


### PR DESCRIPTION
**STEPS TO REPRODUCE**
1. Login to PM4 instance.
2. Create a process with a script task before a form task.
3. Create a script to set the condition for the required fields. In the example the condition used is "YQP_SUBMIT_SAVE" => "SUBMIT"
4. Create a screen with two multicolumns one inside the other and put fields inside them.
5. The fields should have the RequiredIf property and the condition used there should be the condition previously defined in the script created.
6. Assign the script and screen created to the corresponding tasks in the process.
7. Assign the admin user as requestor.
8. Run a case

**RELATED TICKET**
https://processmaker.atlassian.net/browse/FOUR-14272

ci:next