### PR TITLE
Bugfix/FOUR-17713: 39852 Immatics Corrupted Process

### DIFF
--- a/src/components/FormInput.vue
+++ b/src/components/FormInput.vue
@@ -5,12 +5,12 @@
       v-bind="$attrs"
       v-uni-id="name"
       :value="value"
-      @input="$emit('input', $event.target.value)"
+      @input="handleInput"
       :name="name"
       class="form-control"
       :class="classList"
       v-on:blur="formatFloatValue()"
-    >
+    />
     <display-errors v-if="error || (validator && validator.errorCount)" :name="name" :error="error" :validator="validator"/>
     <small v-if="helper" class="form-text text-muted" v-html="helper"/>
   </div>
@@ -39,7 +39,13 @@ export default {
     'helper',
     'name',
     'controlClass',
+    'validateKeyStrokes',
   ],
+  data() {
+    return {
+      validator: null,
+    }
+  },
   computed:{
     classList() {
       return {
@@ -48,10 +54,18 @@ export default {
       }
     }
   },
-  data() {
-    return {
-      validator: null
+  methods: {
+    handleInput(event) {
+      if (this.validateKeyStrokes) {
+        const allowedVariableRegex = new RegExp(this.validateKeyStrokes);
+        if (!allowedVariableRegex.test(event.target.value)) {
+          this.$emit("input", this.value);
+          event.target.value = this.value;
+          return;
+        }
+      }
+      this.$emit("input", event.target.value);
     }
-  },
-}
+  }
+};
 </script>


### PR DESCRIPTION
## Issue & Reproduction Steps
Please refer to https://processmaker.atlassian.net/browse/FOUR-17713

## Solution
- For every key stoke, if passed validateKeyStrokes regexp, it will validate the pressed keys are allowed.

## Related Tickets & Packages
- [FOUR-17713](https://processmaker.atlassian.net/browse/FOUR-17713)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


ci:next
ci:modeler:bugfix/FOUR-17713

[FOUR-17713]: https://processmaker.atlassian.net/browse/FOUR-17713?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ