### PR TITLE
FOUR-18927: Issue with the PMQL

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -241,10 +241,18 @@ export default {
     isMultiSelectDisabled() {
       return this.options.allowMultiSelect === false;
     },
+    hasNestedProperty(obj, path) {
+      return path.split(".").reduce((acc, part) => acc && acc[part], obj);
+    },
     renderPmql(pmql) {
       if (typeof pmql !== "undefined" && pmql !== "" && pmql !== null) {
         const data = this.makeProxyData();
-        return Mustache.render(pmql, data);
+        const preprocessedTemplate = pmql.replace(/{{\s*([\w.]+)\s*}}/g, (match, key) => {
+          return this.hasNestedProperty(data, key) ? match : `[[[${key}]]]`;
+        });
+        const output = Mustache.render(preprocessedTemplate, data);
+        const last = Mustache.render(output.replace("[[[", "{{").replace("]]]", "}}"), { data });
+        return last;
       }
       return "";
     },


### PR DESCRIPTION
### Steps to Reproduce:

- Impor the next collection and screen:
Collection: [services.json](https://github.com/user-attachments/files/17033333/services.json)
Screen: [Bug.json](https://github.com/user-attachments/files/17033335/Bug.json)

- Add a line input text and a select list with dataconnector configuration 
- Add the PMQL filter using the older version 
data.SRV_ACRONYM = "{{data.SRI_SERVICE}}"
  and verify that the select list is not populated
- Update to the current version and modify the filter to:
data.SRV_ACRONYM = "{{SRI_SERVICE}}"
  and verify that the select list is populated
  
  
Current Behavior:

In the current version, with the syntax data.SRV_ACRONYM = "{{SRI_SERVICE}}" is accepted only,

Expected Behavior:
The filter should work correctly in the current version with the syntax data.SRV_ACRONYM = "{{data.SRI_SERVICE}}", just as it did in the older version.

### Solution:
Both syntaces now are accepted:
data.SRV_ACRONYM = "{{data.SRI_SERVICE}}"
data.SRV_ACRONYM = "{{SRI_SERVICE}}"

ci:next
ci:deploy