### PR TITLE
FOUR-19715: Mustache Variables Not Rendered in Field Validation Messages

### DIFF
--- a/src/components/mixins/validation.js
+++ b/src/components/mixins/validation.js
@@ -2,6 +2,7 @@ import Validator from "@chantouchsek/validatorjs";
 import moment from "moment-timezone";
 import ProxyData from "./ProxyData";
 import { get, has } from "lodash";
+import Mustache from "mustache";
 
 export default {
   name: "ValidationMixin",
@@ -140,7 +141,8 @@ export default {
         this.validator = new Validator(data, rules, {
           validationMessages: this.validationMessages ? this.validationMessages : null
         });
-        this.validator.setAttributeNames({ [fieldName]: this.label });
+        const renderedLabel = Mustache.render(this.label, data);
+        this.validator.setAttributeNames({ [fieldName]: renderedLabel });
         this.validator.errors.first(this.name);
         // Validation will not run until you call passes/fails on it
         this.validator.passes();


### PR DESCRIPTION
Mustache variables are not properly rendered in field validation messages. When a mustache variable is used in a field label, it should be correctly rendered within the validation error messages. Currently, the mustache variable appears as plain text (e.g., {{name}}) instead of showing the expected dynamic value, leading to confusion in the form’s validation feedback.

**Steps to Reproduce:**

1. Create a form with conversational input.
2. Add a field label that includes a mustache variable, such as {{username}}.
3. Set up validation rules for that field (e.g., required field).
4. Submit the form without filling in the field to trigger the validation error message.
5. The mustache variable in the validation message is not replaced by its corresponding value; it shows up as plain text.

**Expected Behavior:**
- Mustache variables should be properly rendered in the validation error messages, reflecting the dynamic value that is used in the field label.

## Solution Implemented
- Used Mustache.render to dynamically parse and render the mustache variables in the field label.
-  This approach ensures that validation messages display correctly with the dynamically rendered label.

Before:
![before](https://github.com/user-attachments/assets/c43d1acd-e8e6-41c3-bf57-80b3eed20761)

After:
![after](https://github.com/user-attachments/assets/7b59f86c-adaa-4891-96fd-1ebf4ae457ca)

## Related ticket
- [FOUR-19715](https://processmaker.atlassian.net/browse/FOUR-19715)


[FOUR-19715]: https://processmaker.atlassian.net/browse/FOUR-19715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ