### PR TITLE
Task/FOUR-19875: aria-label property is the same in all options in the select list component generating unexpected behaviors for screen readers

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -5,6 +5,7 @@
       v-if="options.renderAs === 'dropdown'"
       :option-value="optionsKey"
       :option-content="optionsValue"
+      :option-aria-label="optionsAriaLabel"
       v-uni-id="name"
       v-model="valueProxy"
       :placeholder="placeholder ? placeholder : $t('Select...')"
@@ -26,6 +27,7 @@
         :name="name"
         :option-value="optionsKey"
         :option-content="optionsValue"
+        :option-aria-label="optionsAriaLabel"
         :options="selectListOptionsWithSelected"
         :react-options="reactOptions"
         :emit-objects="options.valueTypeReturned === 'object'"
@@ -39,6 +41,7 @@
         :name="name"
         :option-value="optionsKey"
         :option-content="optionsValue"
+        :option-aria-label="optionsAriaLabel"
         :options="selectListOptionsWithSelected"
         :react-options="reactOptions"
         :emit-objects="options.valueTypeReturned === 'object'"
@@ -159,7 +162,8 @@ export default {
         valueTypeReturned: this.options.valueTypeReturned,
         dataName: this.options.dataName,
         value: this.options.value,
-        key: this.options.key
+        key: this.options.key,
+        ariaLabel: this.options.optionAriaLabel
       };
     },
     valueProxy: {
@@ -212,6 +216,16 @@ export default {
         return "content";
       }
       return "__content__";
+    },
+    optionsAriaLabel() {
+      if (
+        this.options.dataSource &&
+        (this.options.dataSource === "provideData" ||
+          this.isCollection)
+      ) {
+        return "ariaLabel";
+      }
+      return "__ariaLabel__";
     },
     classList() {
       return {
@@ -384,6 +398,7 @@ export default {
     formatCollectionRecordResults(record) {
       let content = get(record, this.collectionOptions.labelField);
       let value = get(record, this.collectionOptions.valueField);
+      let ariaLabel = get(record, this.collectionOptions.ariaLabelField || this.collectionOptions.labelField);
 
       // Special handler for file uploads
       if (typeof content === 'object' && ('name' in content)) {
@@ -395,7 +410,8 @@ export default {
 
       return {
         value: String(value),
-        content: String(content)
+        content: String(content),
+        ariaLabel: String(ariaLabel)
       };
     },
     includeFilterInPmql(pmql) {
@@ -557,15 +573,32 @@ export default {
             ? Mustache.render(this.options.value, item)
             : Mustache.render(`{{${this.options.value || "content"}}}`, item);
 
+        // Modified ariaLabel handling        
+        let itemAriaLabel = itemContent;
+        if (this.options.optionAriaLabel) {
+          itemAriaLabel = this.options.optionAriaLabel.indexOf("{{") >= 0
+            ? Mustache.render(this.options.optionAriaLabel, item)
+            : Mustache.render(`{{${this.options.optionAriaLabel || "ariaLabel"}}}`, item);
+        }
+
         Mustache.escape = escape; // Reset mustache to original escape function
 
         parsedOption[this.optionsValue] = itemContent;
+        parsedOption[this.optionsAriaLabel] = itemAriaLabel;
+
         if (this.options.valueTypeReturned === "object") {
           parsedOption = suffix.length > 0 ? get(item, suffix) : item;
           if (!parsedOption.hasOwnProperty(this.optionsValue)) {
             Object.defineProperty(parsedOption, this.optionsValue, {
               get() {
                 return itemContent;
+              }
+            });
+          }
+          if (!parsedOption.hasOwnProperty(this.optionsAriaLabel)) {
+            Object.defineProperty(parsedOption, this.optionsAriaLabel, {
+              get() {
+                return itemAriaLabel;
               }
             });
           }
@@ -580,9 +613,15 @@ export default {
       }
       const suffix = this.attributeParent(this.options.value);
       let contentProperty = this.options.value;
+      let ariaLabelProperty = this.options.ariaLabel || this.options.value;
+
       if (contentProperty.indexOf("{{") === -1) {
         contentProperty = `{{ ${contentProperty} }}`;
       }
+      if (ariaLabelProperty.indexOf("{{") === -1) {
+        ariaLabelProperty = `{{ ${ariaLabelProperty} }}`;
+      }
+
       if (!parsedOption.hasOwnProperty(this.optionsValue)) {
         Object.defineProperty(parsedOption, this.optionsValue, {
           get() {
@@ -597,6 +636,22 @@ export default {
           }
         });
       }
+
+      if (!parsedOption.hasOwnProperty(this.optionsAriaLabel)) {
+        Object.defineProperty(parsedOption, this.optionsAriaLabel, {
+          get() {
+            // note this = parsedOption
+            let data = {};
+            if (suffix) {
+              set(data, suffix, this);
+            } else {
+              data = this;
+            }
+            return Mustache.render(ariaLabelProperty, data);
+          }
+        });
+      }
+
       return parsedOption;
     },
     stripMustache(str) {

--- a/src/components/FormSelectList/CheckboxView.vue
+++ b/src/components/FormSelectList/CheckboxView.vue
@@ -10,6 +10,7 @@
           v-model="selected"
           v-bind="$attrs"
           :disabled="isReadOnly"
+          :aria-label="getOptionAriaLabel(option)"
           @change="$emit('input', selected)"
       >
       <label :class="labelClass" v-uni-for="getOptionId(option, index)">
@@ -32,6 +33,7 @@ export default {
     'value',
     'optionValue',
     'optionContent',
+    'optionAriaLabel',
     'options',
     'error',
     'helper',
@@ -74,6 +76,10 @@ export default {
     },
     getOptionContent(option) {
       return option[this.optionContent || 'content'];
+    },
+    getOptionAriaLabel(option) {
+      const ariaLabel = option[this.optionAriaLabel || "ariaLabel"];
+      return (!ariaLabel || ariaLabel === "") ? this.getOptionContent(option) : ariaLabel;
     },
     getOptionId(option, index) {
       return `${this.name}-${this.getOptionValue(option)}-${index}`;

--- a/src/components/FormSelectList/OptionboxView.vue
+++ b/src/components/FormSelectList/OptionboxView.vue
@@ -10,6 +10,7 @@
           v-model="selected"
           v-bind="$attrs"
           :disabled="isReadOnly"
+          :aria-label="getOptionAriaLabel(option)"
       >
       <label :class="labelClass" v-uni-for="getOptionId(option, index)">
         {{getOptionContent(option)}}
@@ -38,6 +39,7 @@ export default {
     'controlClass',
     'emitObjects',
     'emitArray',
+    'optionAriaLabel'
   ],
   data() {
     return {
@@ -76,6 +78,10 @@ export default {
     },
     getOptionContent(option) {
       return option[this.optionContent || 'content'];
+    },
+    getOptionAriaLabel(option) {
+      const ariaLabel = option[this.optionAriaLabel || "ariaLabel"];
+      return (!ariaLabel || ariaLabel === "") ? this.getOptionContent(option) : ariaLabel;
     },
     getOptionId(option, index) {
       return `${this.name}-${this.getOptionValue(option)}-${index}`;


### PR DESCRIPTION
## Issue & Reproduction Steps

**Steps to Reproduce:**

- Create a new screen
- Use the Select List component in the screen
- Configure the aria-label in Advanced property

**Current Behavior:**
The same aria-label is repeated for each option in the Select List. This is causing that the screen readers for disabilities reads the label question every time. This behavior is unexpected for the customer.

**Expected Behavior:**

ProcessMaker should allow configure the aria-label for each option in the aria-label property. One for the label and one for each option in the Select List component for the screen readers.

## Solution
- Added area label option for checkbox renderAs mode, for provide data, request data, data connectors and collections.

## How to Test
Test the steps above

## Related Tickets & Packages
- [FOUR-19875](https://processmaker.atlassian.net/browse/FOUR-19875)
- [Screen Builder PR](https://github.com/ProcessMaker/screen-builder/pull/1769)
- [Vue Form Elements PR](https://github.com/ProcessMaker/vue-form-elements/pull/442)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:screen-builder:task/FOUR-19875


[FOUR-19875]: https://processmaker.atlassian.net/browse/FOUR-19875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ