### PR TITLE
changed the custom rules to avoid conflicts

### DIFF
--- a/src/components/mixins/validation.js
+++ b/src/components/mixins/validation.js
@@ -119,19 +119,28 @@ export default {
         let data = this.validationData ? this.validationData : { [fieldName]: this.value };
         let validationRules = "";
 
-        if (typeof this.validation !== "string" && this.validation.length) {
+        if (Array.isArray(this.validation)) {
           let rules = [];
 
           this.validation.forEach((configs) => {
             if (!configs.value) {
               return;
             }
-            rules.push(configs.value);
+            const ruleValue = configs.value
+              .replace('after:', 'after_date:')
+              .replace('before:', 'before_date:')
+              .replace('after_or_equal:', 'after_or_equal_date:')
+              .replace('before_or_equal:', 'before_or_equal_date:');
+            rules.push(ruleValue);
           });
 
           validationRules = rules;
         } else {
-          validationRules = this.validation;
+          validationRules = this.validation
+            .replace('after:', 'after_date:')
+            .replace('before:', 'before_date:')
+            .replace('after_or_equal:', 'after_or_equal_date:')
+            .replace('before_or_equal:', 'before_or_equal_date:');
         }
 
         let rules = {
@@ -172,7 +181,7 @@ export default {
       );
 
       Validator.register(
-        "after",
+        "after_date",
         function (date, params) {
           // checks if incoming 'params' is a date or a key reference.
           let checkDate = moment(params);
@@ -185,11 +194,11 @@ export default {
 
           return inputDate > afterDate;
         },
-        "The :attribute must be after :after."
+        "The :attribute must be after :after_date."
       );
 
       Validator.register(
-        "after_or_equal",
+        "after_or_equal_date",
         function (date, params) {
           // checks if incoming 'params' is a date or a key reference.
           let checkDate = moment(params);
@@ -202,11 +211,11 @@ export default {
 
           return inputDate >= equalOrAfterDate;
         },
-        "The :attribute must be equal or after :after_or_equal."
+        "The :attribute must be equal or after :after_or_equal_date."
       );
 
       Validator.register(
-        "before",
+        "before_date",
         function (date, params) {
           // checks if incoming 'params' is a date or a key reference.
           let checkDate = moment(params);
@@ -219,11 +228,11 @@ export default {
 
           return inputDate < beforeDate;
         },
-        "The :attribute must be before :before."
+        "The :attribute must be before :before_date."
       );
 
       Validator.register(
-        "before_or_equal",
+        "before_or_equal_date",
         function (date, params) {
           // checks if incoming 'params' is a date or a key reference.
           let checkDate = moment(params);
@@ -236,7 +245,7 @@ export default {
 
           return inputDate <= beforeDate;
         },
-        "The :attribute must be equal or before :before_or_equal."
+        "The :attribute must be equal or before :before_or_equal_date."
       );
 
       Validator.register(


### PR DESCRIPTION
## Issue & Reproduction Steps
The after date validation rule in a line input of a conversational screen is not working

## Solution
Registered new rules to avoid conflicts default rules

## How to Test
Log in 
Go to  Designer
Click on screens
Create a  screen converastional
In screen conversatinal create a line input
Configure  line input to,  validation rules  after date
Save  the scren
Click on preview
place a date after the one configured in the control

## Related Tickets & Packages
https://processmaker.atlassian.net/browse/FOUR-19221