### PR TITLE
Cannot create a pmblock with the language translation Português and Na Vosa Vakaviti (Fijian)

### DIFF
--- a/src/components/mixins/DataFormat.js
+++ b/src/components/mixins/DataFormat.js
@@ -8,7 +8,7 @@ let globalObject = typeof window === 'undefined'
   : window;
 
 if (globalObject.ProcessMaker?.user?.lang) {
-  Validator.useLang(globalObject.ProcessMaker.user.lang);
+  globalObject.ProcessMaker.setValidatorLanguage(Validator, globalObject.ProcessMaker.user.lang);
 }
 
 Validator.register('custom-date', function(date) {

--- a/src/components/mixins/DataFormat.js
+++ b/src/components/mixins/DataFormat.js
@@ -7,7 +7,7 @@ let globalObject = typeof window === 'undefined'
   ? global
   : window;
 
-if (globalObject.ProcessMaker?.user?.lang) {
+if (globalObject.ProcessMaker?.user?.lang && typeof globalObject.ProcessMaker.setValidatorLanguage === 'function') {
   globalObject.ProcessMaker.setValidatorLanguage(Validator, globalObject.ProcessMaker.user.lang);
 }
 

--- a/src/components/mixins/validation.js
+++ b/src/components/mixins/validation.js
@@ -111,7 +111,9 @@ export default {
       } else if (document.documentElement.lang) {
         lang = document.documentElement.lang;
       }
-      globalObject.ProcessMaker.setValidatorLanguage(Validator, lang);
+      if (typeof globalObject.ProcessMaker.setValidatorLanguage === 'function') {
+        globalObject.ProcessMaker.setValidatorLanguage(Validator, lang);
+      }
 
       globalObject.validatorLanguageSet = true;
     },

--- a/src/components/mixins/validation.js
+++ b/src/components/mixins/validation.js
@@ -105,11 +105,13 @@ export default {
         return;
       }
 
+      let lang = 'en';
       if (has(globalObject, "ProcessMaker.user.lang")) {
-        Validator.useLang(globalObject.ProcessMaker.user.lang);
+        lang = globalObject.ProcessMaker.user.lang;
       } else if (document.documentElement.lang) {
-        Validator.useLang(document.documentElement.lang);
+        lang = document.documentElement.lang;
       }
+      globalObject.ProcessMaker.setValidatorLanguage(Validator, lang);
 
       globalObject.validatorLanguageSet = true;
     },


### PR DESCRIPTION
## Issue & Reproduction Steps

1. Log-in
2. Go to translations and create a non major language like Afrikaans, Gallician, Catalan
3. Generate all the translations of the plataform for the language of step 2.
4. Select as the System language the language selected in step2.
5. Create a PMBlock


**Current Behavior**
The PMBlock configuation tabs are note displayed

**Expected Behavior**
A user should be able to create a PM Block with any language

## Related Tickets & Packages
- https://processmaker.atlassian.net/browse/FOUR-21898

## Solution:
The problem was caused by the limited set of translations that the library validator.js supports. We added code to use english as a fallback language.

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.

ci:processmaker:bugfix/FOUR-21898
ci:package-pm-blocks:bugfix/FOUR-21898
ci:screen-builder:bugfix/FOUR-21898
