### PR TITLE
Required if is not showing red asterisk (*) on Nested screens

### DIFF
--- a/src/components/FormCheckbox.vue
+++ b/src/components/FormCheckbox.vue
@@ -49,6 +49,7 @@ export default {
     'toggle',
     'checked',
     'initiallyChecked',
+    'transientData'
   ],
   computed: {
     validatorErrors() {

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -105,7 +105,8 @@ export default {
       default: false
     },
     minDate: { type: [String, Boolean], default: false },
-    maxDate: { type: [String, Boolean], default: false }
+    maxDate: { type: [String, Boolean], default: false },
+    transientData: { type: Object, default: () => ({}) }
   },
   data() {
     // set to the browser's timezone because the vue-date-pick always works

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -95,7 +95,8 @@ export default {
     "controlClass",
     "validationData",
     "placeholder",
-    "multiple"
+    "multiple",
+    "transientData"
   ],
   data() {
     return {

--- a/src/components/FormTextArea.vue
+++ b/src/components/FormTextArea.vue
@@ -65,7 +65,8 @@ export default {
     "controlClass",
     "richtext",
     "readonly",
-    "rows"
+    "rows",
+    "transientData"
   ],
   data() {
     return {


### PR DESCRIPTION
## Issue & Reproduction Steps
When a field has a RequireIf validation set, the ( * ) shown for a required field is not displayed.

## Solution
- Add prop TransientData

## How to Test

1. Create a process
2. Create a screen and add some fields required if
3. Create a nested screen with some fields that are required and add them to the first screen.
4. Create a case and try to show the RequireIf functionality.

## Related Tickets & Packages
- [FOUR-22102](https://processmaker.atlassian.net/browse/FOUR-22102)

## Code Review Checklist
- [ ] I have pulled this code locally and tested it on my instance, along with any associated packages.
- [ ] This code adheres to [ProcessMaker Coding Guidelines](https://github.com/ProcessMaker/processmaker/wiki/Coding-Guidelines).
- [ ] This code includes a unit test or an E2E test that tests its functionality, or is covered by an existing test.
- [ ] This solution fixes the bug reported in the original ticket.
- [ ] This solution does not alter the expected output of a component in a way that would break existing Processes.
- [ ] This solution does not implement any breaking changes that would invalidate documentation or cause existing Processes to fail.
- [ ] This solution has been tested with enterprise packages that rely on its functionality and does not introduce bugs in those packages.
- [ ] This code does not duplicate functionality that already exists in the framework or in ProcessMaker.
- [ ] This ticket conforms to the PRD associated with this part of ProcessMaker.


[FOUR-22102]: https://processmaker.atlassian.net/browse/FOUR-22102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ