### PR TITLE
FOUR-23857: When I add a pmblock configured with a collection in select list, errors are shown in the modeler

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -401,20 +401,24 @@ export default {
     formatCollectionRecordResults(record) {
       let content = get(record, this.collectionOptions.labelField);
       let value = get(record, this.collectionOptions.valueField);
-      let ariaLabel = get(record, this.collectionOptions.ariaLabelField || this.collectionOptions.labelField);
+      const ariaLabel = get(record, this.collectionOptions.ariaLabelField || this.collectionOptions.labelField);
 
-      // Special handler for file uploads
-      if (typeof content === 'object' && ('name' in content)) {
+      // Special handler for file uploads.
+      // Ensure 'content' is a non-null object before checking for 'name' key.
+      if (content && typeof content === "object" && "name" in content) {
         content = content.name;
       }
-      if (typeof value === 'object' && ('id' in value)) {
+
+      // Ensure 'value' is a non-null object before checking for 'id' key.
+      if (value && typeof value === "object" && "id" in value) {
         value = value.id;
       }
 
+      // Safely convert to string, fallback to empty string if null or undefined.
       return {
-        value: String(value),
-        content: String(content),
-        ariaLabel: String(ariaLabel)
+        value: String(value ?? ""),
+        content: String(content ?? ""),
+        ariaLabel: String(ariaLabel ?? "")
       };
     },
     includeFilterInPmql(pmql) {
@@ -576,7 +580,7 @@ export default {
             ? Mustache.render(this.options.value, item)
             : Mustache.render(`{{${this.options.value || "content"}}}`, item);
 
-        // Modified ariaLabel handling        
+        // Modified ariaLabel handling
         let itemAriaLabel = itemContent;
         if (this.options.optionAriaLabel) {
           itemAriaLabel = this.options.optionAriaLabel.indexOf("{{") >= 0


### PR DESCRIPTION
## Issue
When using a Select List with a collection as the data source, if any collection record contains null in the labelField or valueField, the application crashes with:

```
TypeError: right-hand side of 'in' should be an object, got null
```

This happened in formatCollectionRecordResults, which was attempting to use the in operator on a potentially null value.

## Solution
- Added null-checks to ensure content and value are valid objects before using the in operator.
- Used String(value ?? '') to gracefully handle undefined/null values.

## How to Test
1. Create or use a Collection where some fields in labelField or valueField are null.
2. Bind a Select List component to that collection.
3. Load the form/screen and confirm that:
  - The Select List loads without crashing.
  - Entries with null values show as empty strings instead of throwing errors.
4. Also test a “normal” case where records have expected structure (e.g. value.id and content.name) to ensure no regressions.

## Ticket
- [FOUR-23857](https://processmaker.atlassian.net/browse/FOUR-23857)
ci:deploy

.

[FOUR-23857]: https://processmaker.atlassian.net/browse/FOUR-23857?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ