### PR TITLE
FOUR-25651: Embedded Malicious Code in eslint-config-prettier

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "babel-jest": "^27.5.1",
         "eslint": "^7.32.0",
         "eslint-config-airbnb-base": "^15.0.0",
-        "eslint-config-prettier": "^8.5.0",
+        "eslint-config-prettier": "^8.10.2",
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-vue": "^9.3.0",
@@ -4166,7 +4166,9 @@
       }
     },
     "node_modules/eslint-config-prettier": {
-      "version": "8.10.0",
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.10.2.tgz",
+      "integrity": "sha512-/IGJ6+Dka158JnP5n5YFMOszjDWrXggGz1LaK/guZq9vZTmniaKlHcsscvkAhn9y4U+BU3JuUdYvtAMcv30y4A==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "babel-jest": "^27.5.1",
     "eslint": "^7.32.0",
     "eslint-config-airbnb-base": "^15.0.0",
-    "eslint-config-prettier": "^8.5.0",
+    "eslint-config-prettier": "^8.10.2",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-vue": "^9.3.0",


### PR DESCRIPTION
Per [CVE-2025-54313](https://security.snyk.io/vuln/SNYK-JS-ESLINTCONFIGPRETTIER-10873299), a malicious actor compromised the credentials of one of the maintainers via a phishing attack. This allowed the attacker to publish tampered versions of the package to npm.

Per a scan of our GitHub repositories, the following packages will need to be upgraded to version 8.10.2, 9.1.2, 10.1.8 or higher.