### PR TITLE
[45885] Start Timer Event configuration affected by the user's profile date format

### DIFF
--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -153,6 +153,7 @@ export default {
           // If forceDateTime is true and no time pattern exists, ensure the format includes hh:mm A
           format = `${format.replace(/[\sHh:msaAzZ]/g, '')} hh:mm A`;
         }
+        return format;
       }
       return getUserDateFormat();
     },

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -145,7 +145,16 @@ export default {
       return this.dataFormat === "datetime";
     },
     format() {
-      return this.datepicker ? getUserDateTimeFormat() : getUserDateFormat();
+      let format = this.datepicker ? getUserDateTimeFormat() : getUserDateFormat();
+      if (this.datepicker) {
+        // Check if the format already includes time patterns (hh:mm A or HH:mm)
+        const hasTimePattern = /[Hh]{1,2}:[mM]{1,2}/.test(format);
+        if (!hasTimePattern) {
+          // If forceDateTime is true and no time pattern exists, ensure the format includes hh:mm A
+          format = format.replace(/[\sHh:msaAzZ]/g, '') + ' hh:mm A';
+        }
+      }
+      return format;
     },
     classList() {
       return {

--- a/src/components/FormDatePicker.vue
+++ b/src/components/FormDatePicker.vue
@@ -145,16 +145,16 @@ export default {
       return this.dataFormat === "datetime";
     },
     format() {
-      let format = this.datepicker ? getUserDateTimeFormat() : getUserDateFormat();
       if (this.datepicker) {
+        let format = getUserDateTimeFormat();
         // Check if the format already includes time patterns (hh:mm A or HH:mm)
         const hasTimePattern = /[Hh]{1,2}:[mM]{1,2}/.test(format);
         if (!hasTimePattern) {
           // If forceDateTime is true and no time pattern exists, ensure the format includes hh:mm A
-          format = format.replace(/[\sHh:msaAzZ]/g, '') + ' hh:mm A';
+          format = `${format.replace(/[\sHh:msaAzZ]/g, '')} hh:mm A`;
         }
       }
-      return format;
+      return getUserDateFormat();
     },
     classList() {
       return {


### PR DESCRIPTION
Ticket [FOUR-25088](https://processmaker.atlassian.net/browse/FOUR-25088)

According to the date picker configuration, if it is a datetime type, a hh:mm is added by default if the date and time configuration does not have the time.

[FOUR-25088]: https://processmaker.atlassian.net/browse/FOUR-25088?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ