### PR TITLE
FOUR-28514: Ensure duplicated select-list radios render independently while sharing the same variable

### DIFF
--- a/src/components/FormSelectList/OptionboxView.vue
+++ b/src/components/FormSelectList/OptionboxView.vue
@@ -6,7 +6,7 @@
         v-uni-id="getOptionId(option, index)"
         :class="inputClass"
         type="radio"
-        :name="`${name}`"
+        :name="inputName"
         :value="emitObjects ? option : getOptionValue(option)"
         v-bind="$attrs"
         :disabled="isReadOnly"
@@ -48,6 +48,11 @@ export default {
     return {
       selected: []
     };
+  },
+  computed: {
+    inputName() {
+      return `${this.name}-${this._uid}`;
+    }
   },
   watch: {
     value(val) {


### PR DESCRIPTION
Radio inputs rendered by FormSelectList shared the same HTML name when duplicated with the same variable, causing the browser to group both instances as a single radio group. This broke visual sync and required extra clicks for selection.

## Solution
- Namespaced the radio name attribute in OptionboxView.vue with a per-instance UID so each component renders an isolated radio group while still syncing via v-model.

## How to test
- Open the screen from FOUR-28514 in Screen Builder Preview.
- Duplicate a select-list rendered as radios that uses the same variable.
- Click any option in one group; verify the same option appears selected in the other group without deselecting it or requiring a second click.
- Confirm the Data Preview shows the selected value and updates when toggling between options.

## Ticket
- [FOUR-28514](https://processmaker.atlassian.net/browse/FOUR-28514)

[FOUR-28514]: https://processmaker.atlassian.net/browse/FOUR-28514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

cy:deploy