### PR TITLE
Fix visibility of required asterisk on toggle checkboxes

### DIFF
--- a/src/components/FormCheckbox.vue
+++ b/src/components/FormCheckbox.vue
@@ -10,7 +10,7 @@
         :checked="isChecked"
         @change="$emit('change', $event.target.checked)"
       >
-      <required-asterisk />
+      <required-asterisk :toggle-enabled="toggle"/>
       <label :class="labelClass" v-uni-for="name">{{label}}</label>
       <div v-if="(validator && validator.errorCount) || error" class="invalid-feedback">
         <div v-for="(error, index) in validatorErrors" :key="index">{{error}}</div>

--- a/src/components/common/RequiredAsterisk.vue
+++ b/src/components/common/RequiredAsterisk.vue
@@ -1,11 +1,34 @@
 <template>
-    <span v-if="$parent.required" :title="$t('required')" class="required-asterisk">*</span>
+    <span v-if="$parent.required" :title="$t('required')" :class="classList">*</span>
 </template>
 
+<script>
+export default {
+  props: {
+    toggleEnabled: {
+      type: Boolean,
+      default: false
+    }
+  },
+  computed: {
+    classList() {
+      return {
+        'required-asterisk': true,
+        'toggle-enabled': this.toggleEnabled
+      }
+    }
+  }
+}
+</script>
 <style>
 .required-asterisk {
   color: #dc3545;
   padding-right: 0.5em;
+}
+
+.required-asterisk.toggle-enabled {
+  position:relative;
+  left: -33px;
 }
 
 .conversational-chat .required-asterisk {


### PR DESCRIPTION

The required asterisk did not appear on checkboxes when toggle-style (custom-switch) was enabled. Bootstrap’s toggle styling uses `::before` and `::after` pseudo-elements on the control, which overlapped the asterisk placement and hid it from view.

This change adds a toggle-enabled class to RequiredAsterisk when used inside a toggle checkbox, and applies CSS to reposition the asterisk so it remains visible.

## Solution
- Add optional `toggleEnabled` prop to `RequiredAsterisk`
- Pass toggle from `FormCheckbox` into `RequiredAsterisk` via `:toggle-enabled`
- Apply `toggle-enabled` alongside `required-asterisk` when toggle mode is active
- Add positioning styles (`.required-asterisk.toggle-enabled`) to offset the asterisk and avoid overlap with toggle pseudo-elements

## Note:
Due to the layout of the toggle control, the asterisk appears in a different position than on a standard checkbox: before the toggle, rather than after the checkbox and before the label (the default placement).

<img width="223" height="97" alt="Screenshot 2026-06-23 at 3 30 37 PM" src="https://github.com/user-attachments/assets/590ffc8a-1df3-4de7-bdd5-21a3920ee8be" />


## How to test

1.  Render a required checkbox with toggle disabled,  asterisk appears in the default position
2. Render a required checkbox with toggle enabled, asterisk is visible and correctly positioned


## Related Tickets
[FOUR-29727](https://processmaker.atlassian.net/browse/FOUR-29727)


[FOUR-29727]: https://processmaker.atlassian.net/browse/FOUR-29727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ