### PR TITLE
FOUR-31978 SCREEN BUILDER Use apiClient cache for repeated GET list options

### DIFF
--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -78,8 +78,8 @@ const MAX_COLLECTION_RECORDS = 100;
 const API_CLIENT_CACHE_CONFIG = {
   cache: {
     enabled: true,
-    debug: true
-  }
+    debug: false,
+  },
 };
 
 export default {

--- a/src/components/FormSelectList.vue
+++ b/src/components/FormSelectList.vue
@@ -75,6 +75,13 @@ const uniqIdsMixin = createUniqIdsMixin();
 
 const MAX_COLLECTION_RECORDS = 100;
 
+const API_CLIENT_CACHE_CONFIG = {
+  cache: {
+    enabled: true,
+    debug: true
+  }
+};
+
 export default {
   components: {
     OptionboxView,
@@ -309,7 +316,8 @@ export default {
       const params = {
         config: {
           endpoint: selectedEndPoint
-        }
+        },
+        ...API_CLIENT_CACHE_CONFIG
       };
       const pmql = this.renderPmql(this.options.pmqlQuery);
       if (pmql) {
@@ -360,7 +368,8 @@ export default {
       }
 
       const options = {
-        params: { per_page: MAX_COLLECTION_RECORDS }
+        params: { per_page: MAX_COLLECTION_RECORDS },
+        ...API_CLIENT_CACHE_CONFIG
       };
 
       let pmql = this.renderPmql(this.collectionOptions.pmql);
@@ -423,7 +432,10 @@ export default {
       }
 
       this.loading = true;
-      const [data] = await this.$dataProvider.getCollectionRecords(this.collectionOptions.collectionId, { params: { pmql } });
+      const [data] = await this.$dataProvider.getCollectionRecords(this.collectionOptions.collectionId, {
+        params: { pmql },
+        ...API_CLIENT_CACHE_CONFIG
+      });
       this.loading = false;
 
       if (data.data && data.data.length > 0) {


### PR DESCRIPTION
## Issue & Reproduction Steps

### SCREEN BUILDER Use apiClient cache for repeated GET list options

## Solution

https://github.com/user-attachments/assets/4dbd8aac-1427-4379-ae37-eea475378a39

## Related Tickets & Packages
[FOUR-31978](https://processmaker.atlassian.net/browse/FOUR-31978)


[FOUR-31978]: https://processmaker.atlassian.net/browse/FOUR-31978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ