### PR TITLE
fix(FOUR-20275): forward submit events from nested modal renderer

### DIFF
--- a/src/components/FormBootstrapVueComponents/BWrapperComponent.vue
+++ b/src/components/FormBootstrapVueComponents/BWrapperComponent.vue
@@ -8,6 +8,8 @@
           :page="form"
           :config="wrapperConfig"
           :current-page="form"
+          @submit="onSubmit"
+          @after-submit="onAfterSubmit"
         />
       </component>
     </div>
@@ -31,7 +33,13 @@ export default {
       show: false,
     };
   },
-  mounted() {
+  methods: {
+    onSubmit(...args) {
+      this.$emit('submit', ...args);
+    },
+    onAfterSubmit(...args) {
+      this.$emit('after-submit', ...args);
+    },
   },
   computed: {
     wrapperConfig() {


### PR DESCRIPTION
The nested vue-form-renderer inside Bootstrap Wrapper did not bubble submit and after-submit events to the parent screen, so submit buttons on modal subpages had no effect.

- Listen for @submit and @after-submit on the nested vue-form-renderer
- Re-emit both events to the parent via onSubmit and onAfterSubmit

https://processmaker.atlassian.net/browse/FOUR-20275

ci:deploy